### PR TITLE
[feat/#9]해시태그 기능 및 검색 기능 추가

### DIFF
--- a/blog/blog/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/blog/blog/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -71,6 +71,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST,"/api/v1/boards/markdown-preview").permitAll()
                         .requestMatchers(HttpMethod.GET,"/api/v1/boards/{boardId}").permitAll()
                         .requestMatchers(HttpMethod.GET,"/api/v1/boards/{boardId}/**").permitAll()
+                        .requestMatchers("/api/v1/boards/search").permitAll()
                         // 카카오 로그인 추가하기
                         // 1. 카카오 Redirect URI (가장 중요한 부분)
                         .requestMatchers("/login/oauth2/code/kakao").permitAll()

--- a/blog/blog/src/main/java/com/example/demo/controller/board/BoardRestController.java
+++ b/blog/blog/src/main/java/com/example/demo/controller/board/BoardRestController.java
@@ -25,6 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Tag(name = "게시판 (Board) API",description = "게시글 생성, 조회 , 수정, 삭제 및 커서 기반 목록 조회 기능을 제공")
@@ -220,14 +221,15 @@ public class BoardRestController {
         }
 
     }
-    /*@Operation(summary = "댓글 작성 토글",description = "인증된 사용자가 해당 게시글에 댓글을 작성합니다.")
-    @ApiResponse(responseCode = "201",description = "댓글 작성 성공")
-    @ApiResponse(responseCode = "401",description = "댓글 작성 권한 오류 401 UNAUTHORIZED")
-    @ApiResponse(responseCode = "404",description = "작성자 ID를 찾을 수 없음")
-    @PostMapping("/comment")
-    public ResponseEntity<BoardCommentDTO>createComment(){
 
-
-        return;
-    }*/
+    @GetMapping("/search")
+    public ResponseEntity<List<BoardResponse>> searchBoards(
+            @RequestParam(value = "keyword",required = false) String keyword,
+            @RequestParam(value = "tagName",required = false) String tagName,
+            @AuthenticationPrincipal CustomUserDetails userDetails)
+    {
+        Long currentMemberId = (userDetails != null) ? userDetails.getMemberId() : null;
+        List<BoardResponse> result = boardService.searchBoards(keyword,tagName,currentMemberId);
+        return ResponseEntity.ok(result);
+    }
 }

--- a/blog/blog/src/main/java/com/example/demo/dto/board/BoardDTO.java
+++ b/blog/blog/src/main/java/com/example/demo/dto/board/BoardDTO.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Setter
 @Getter
 @NoArgsConstructor
@@ -13,6 +15,7 @@ public class BoardDTO {
         private String content;
         private String nickname;
         private String category;
+        private List<String> tags;
     }
 
 

--- a/blog/blog/src/main/java/com/example/demo/dto/board/BoardResponse.java
+++ b/blog/blog/src/main/java/com/example/demo/dto/board/BoardResponse.java
@@ -4,6 +4,8 @@ import com.example.demo.entity.board.BoardEntity;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
 
 public record BoardResponse(
         Long boardId,
@@ -19,6 +21,7 @@ public record BoardResponse(
         int likes,
         int views,
         String category,
+        List<String> tags,
 
         Boolean isAuthor
 ) {
@@ -28,14 +31,19 @@ public record BoardResponse(
     // =========================================================================
     // 💡 1. 오버로딩 메서드 추가 (List.stream().map()에서 사용)
     // =========================================================================
+    // 1-1 태그가 없는 경우(기존 코드 호환용, 빈 리스트 처리)
     public static BoardResponse fromEntity(BoardEntity entity, boolean isAuthor) {
         // 목록 조회 시 엔티티의 Content를 그대로 사용하도록 합니다.
         // 상세 조회 시에만 contentOverride를 사용하므로, 이 경우 null을 전달하여 엔티티의 내용을 사용하도록 위임합니다.
         // 또는 contentOverride를 'Optional'로 만들어서 처리할 수 있지만, 여기서는 단순하게 entity.getContent()를 전달합니다.
-        return fromEntity(entity, entity.getContentSummary(),isAuthor);
+        return fromEntity(entity, Collections.emptyList(),entity.getContentSummary(),isAuthor);
     }
-
-    public static BoardResponse fromEntity(BoardEntity entity,String contentOverrideOrSummary, boolean isAuthor){
+    //1-2 태그가 있는 경우
+    public static BoardResponse fromEntity(BoardEntity entity, List<String> tags,boolean isAuthor){
+        return fromEntity(entity,tags,entity.getContentSummary(),isAuthor);
+    }
+    //1-3 메인 변환 로직(내용 요약/전체구분 + 태그포함)
+    public static BoardResponse fromEntity(BoardEntity entity,List<String> tags,String contentOverrideOrSummary, boolean isAuthor){
         String webFilePath = null;
 
         if(entity.getFilePath() !=null && !entity.getFilePath().isEmpty()) {
@@ -57,6 +65,7 @@ public record BoardResponse(
                 entity.getLikes(),
                 entity.getViews(),
                 entity.getCategory(),
+                tags != null ? tags : Collections.emptyList(),
                 isAuthor
 
         );

--- a/blog/blog/src/main/java/com/example/demo/entity/board/BoardEntity.java
+++ b/blog/blog/src/main/java/com/example/demo/entity/board/BoardEntity.java
@@ -7,6 +7,8 @@ import lombok.*;
 import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Setter
@@ -62,6 +64,9 @@ public class BoardEntity {
     private Long getAuthorMemberId(){
         return this.member != null ? this.member.getMemberId() : null;
     }
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL,orphanRemoval = true)
+    private List<BoardHashtagEntity> boardHashtags = new ArrayList<>();
 
     public void update(
             String title,

--- a/blog/blog/src/main/java/com/example/demo/entity/board/BoardHashtagEntity.java
+++ b/blog/blog/src/main/java/com/example/demo/entity/board/BoardHashtagEntity.java
@@ -1,0 +1,34 @@
+package com.example.demo.entity.board;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "BOARD_HASHTAG",uniqueConstraints = {@UniqueConstraint(columnNames = {"board_id","hashtag_id"})})
+@SequenceGenerator(name = "board_hashtag_seq",sequenceName = "SEQ_BOARD_HASHTAG_ID",allocationSize = 1,initialValue = 1)
+public class BoardHashtagEntity {
+
+    @Id
+    @GeneratedValue(generator = "board_hashtag_seq",strategy = GenerationType.SEQUENCE)
+    @Column(name = "map_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id",nullable = false)
+    private BoardEntity board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hashtag_id",nullable = false)
+    private HashtagEntity hashtag;
+
+    @Builder
+    public BoardHashtagEntity(BoardEntity board, HashtagEntity hashtag){
+        this.board = board;
+        this.hashtag = hashtag;
+    }
+}

--- a/blog/blog/src/main/java/com/example/demo/entity/board/HashtagEntity.java
+++ b/blog/blog/src/main/java/com/example/demo/entity/board/HashtagEntity.java
@@ -1,0 +1,29 @@
+package com.example.demo.entity.board;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "HASHTAG")
+@SequenceGenerator(name = "hashtag_seq",sequenceName = "SEQ_HASHTAG_ID",initialValue = 1,allocationSize = 1)
+public class HashtagEntity {
+
+    @Id
+    @Column(name = "hashtag_id")
+    @GeneratedValue(generator = "hashtag_seq",strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    @Column(nullable = false,unique = true,length = 50)
+    private String name;
+
+    @Builder
+    public HashtagEntity(String name){
+        this.name=name;
+    }
+
+}

--- a/blog/blog/src/main/java/com/example/demo/repository/board/BoardHashtagRepository.java
+++ b/blog/blog/src/main/java/com/example/demo/repository/board/BoardHashtagRepository.java
@@ -1,0 +1,19 @@
+package com.example.demo.repository.board;
+
+import com.example.demo.entity.board.BoardHashtagEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface BoardHashtagRepository extends JpaRepository<BoardHashtagEntity,Long> {
+
+    @Modifying
+    @Query("DELETE FROM BoardHashtagEntity bh WHERE bh.board.boardId = :boardId")
+    void deleteByBoardId(@Param("boardId") Long boardId);
+
+    @Query("SELECT bh FROM BoardHashtagEntity bh WHERE bh.board.boardId = :boardId")
+    List<BoardHashtagEntity> findAllByBoardId(@Param("boardId") Long boardId);
+}

--- a/blog/blog/src/main/java/com/example/demo/repository/board/BoardRepository.java
+++ b/blog/blog/src/main/java/com/example/demo/repository/board/BoardRepository.java
@@ -24,5 +24,12 @@ public interface BoardRepository extends JpaRepository<BoardEntity,Long> {
             "ORDER BY b.inputDate DESC, b.boardId DESC")
     List<BoardEntity> findNextBoardsWithMember(@Param("cursorId") Long cursorId, @Param("cursorDate") LocalDateTime cursorDate, @Param("pageSize")int pageSize);
 
-
+    @Query("SELECT b FROM BoardEntity b " +
+            "LEFT JOIN FETCH b.member m " +
+            "LEFT JOIN b.boardHashtags bh " +
+            "LEFT JOIN bh.hashtag h " +
+            "WHERE (:keyword IS NULL OR b.title LIKE CONCAT('%' , :keyword , '%') OR b.content LIKE CONCAT('%', :keyword, '%')) " +
+            "AND (:tagName IS NULL OR h.name = :tagName) " +
+            "ORDER BY b.inputDate DESC")
+    List<BoardEntity> searchBoards(@Param("keyword") String keyword, @Param("tagName") String tagName);
 }

--- a/blog/blog/src/main/java/com/example/demo/repository/board/HashtagRepository.java
+++ b/blog/blog/src/main/java/com/example/demo/repository/board/HashtagRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.repository.board;
+
+import com.example.demo.entity.board.HashtagEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface HashtagRepository extends JpaRepository<HashtagEntity,Long> {
+
+    Optional<HashtagEntity> findByName(String name);
+}

--- a/blog/blog/src/main/java/com/example/demo/service/board/BoardService.java
+++ b/blog/blog/src/main/java/com/example/demo/service/board/BoardService.java
@@ -30,4 +30,6 @@ public interface BoardService {
     BoardListResponse getBoardsWithCursor(int size, Long cursorId, LocalDateTime cursorDate,Long currentMemberId);
 
     BoardEntity findBoardByIdExceptUser(Long boardId);
+
+    List<BoardResponse> searchBoards(String keyword, String tagName, Long currentMemberId);
 }

--- a/blog/blog/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
+++ b/blog/blog/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
@@ -4,11 +4,14 @@ import com.example.demo.dto.board.BoardDTO;
 import com.example.demo.dto.board.BoardListResponse;
 import com.example.demo.dto.board.BoardResponse;
 import com.example.demo.entity.board.BoardEntity;
+import com.example.demo.entity.board.BoardHashtagEntity;
+import com.example.demo.entity.board.HashtagEntity;
 import com.example.demo.entity.member.MemberEntity;
+import com.example.demo.repository.board.BoardHashtagRepository;
 import com.example.demo.repository.board.BoardRepository;
+import com.example.demo.repository.board.HashtagRepository;
 import com.example.demo.repository.member.MemberRepository;
 import com.example.demo.service.file.FileService;
-import com.example.demo.service.notification.NotificationService;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
 
@@ -41,6 +44,10 @@ public class BoardServiceImpl implements BoardService {
     private final BoardRepository boardRepository;
     private final MemberRepository memberRepository;
     private final FileService fileService;
+
+    //hashtag
+    private final BoardHashtagRepository boardHashtagRepository;
+    private final HashtagRepository hashtagRepository;
 
     private static final MutableDataSet OPTIONS = new MutableDataSet();
     private static final Parser MARKDOWN_PARSER = Parser.builder(OPTIONS).build();
@@ -80,6 +87,22 @@ public class BoardServiceImpl implements BoardService {
         }
     }
 
+    private void saveHashtags(BoardEntity board, List<String> tagNames){
+        if(tagNames ==null || tagNames.isEmpty()){
+            return;
+        }
+        for(String tagName : tagNames){
+            // 공백 제거 및 # 제거
+            String name = tagName.trim().replace("#","");
+            if(name.isEmpty()) continue;
+            // 태그가 존재하면 가져오고 없으면 새로 저장
+            HashtagEntity hashtag = hashtagRepository.findByName(name)
+                    .orElseGet(() -> hashtagRepository.save(new HashtagEntity(name)));
+            // 게시글- 태그 연결 정보 저장
+            boardHashtagRepository.save(new BoardHashtagEntity(board,hashtag));
+        }
+    }
+
     @Override
     @Transactional
     public Long saveNewBoard(BoardDTO boardDTO, Long currentMemberId) {
@@ -115,6 +138,11 @@ public class BoardServiceImpl implements BoardService {
                 .member(author)
                 .build();
         BoardEntity saveEntity = boardRepository.save(entity);
+        // 해시태그 저장 호출
+        if(boardDTO.getTags() != null){
+            saveHashtags(saveEntity,boardDTO.getTags());
+        }
+
         return saveEntity.getBoardId();
     }
 
@@ -189,9 +217,15 @@ public class BoardServiceImpl implements BoardService {
                 fileSize,
                 finalFilePathToSave,
                 contentSummary
-
-
         );
+        //해시태그 업데이트 로직
+        // 1. 기존 연결 모두 삭제
+        boardHashtagRepository.deleteByBoardId(board.getBoardId());
+
+        // 2. 새 태그 목록 저장
+        if(boardDTO.getTags() != null){
+            saveHashtags(board,boardDTO.getTags());
+        }
     }
 
     @Override
@@ -271,7 +305,7 @@ public class BoardServiceImpl implements BoardService {
                 .map(entity -> {
                     Long authorId = (entity.getMember() != null) ? entity.getMember().getMemberId() : null;
                             boolean isAuthor = (currentMemberId != null && authorId != null && currentMemberId.equals(authorId));
-                            return BoardResponse.fromEntity(entity, entity.getContentSummary(), isAuthor);
+                            return BoardResponse.fromEntity(entity,Collections.emptyList(), entity.getContentSummary(), isAuthor);
                         })
                 .collect(Collectors.toList());
         // 5. 다음 커서 값 설정
@@ -306,6 +340,26 @@ public class BoardServiceImpl implements BoardService {
     }
 
     @Override
+    public List<BoardResponse> searchBoards(String keyword, String tagName, Long currentMemberId) {
+
+        String searchKeyword = null;
+        if(keyword != null && !keyword.trim().isEmpty()){
+            searchKeyword = "%" + keyword.trim()+"%";
+        }
+
+        List<BoardEntity> boards = boardRepository.searchBoards(searchKeyword,tagName);
+
+        return boards.stream()
+                .distinct()
+                .map(entity ->{
+                    Long authorId = (entity.getMember() != null) ? entity.getMember().getMemberId() : null;
+                    boolean isAuthor = (currentMemberId != null && authorId != null && currentMemberId.equals(authorId));
+                    return BoardResponse.fromEntity(entity,Collections.emptyList(),entity.getContentSummary(),isAuthor);
+                })
+                .toList();
+    }
+
+    @Override
     public List<BoardResponse> findAllBoards(Long currentMemberId) {
             List<BoardEntity> list = boardRepository.findAllWithMember();
 
@@ -313,7 +367,7 @@ public class BoardServiceImpl implements BoardService {
                 .map(entity -> {
                     Long authorId = (entity.getMember() != null) ? entity.getMember().getMemberId() : null;
                     boolean isAuthor = (currentMemberId != null && authorId != null && currentMemberId.equals(authorId));
-                    return BoardResponse.fromEntity(entity,isAuthor);
+                    return BoardResponse.fromEntity(entity,Collections.emptyList(),entity.getContentSummary(),isAuthor);
                 } )
                 .collect(Collectors.toList());
     }
@@ -323,10 +377,14 @@ public class BoardServiceImpl implements BoardService {
         BoardEntity board = boardRepository.findById(id).orElseThrow(()->new EntityNotFoundException("게시판 아이디를 찾을 수 없습니다."+id));
 
         Long authorId = (board.getMember() != null) ? board.getMember().getMemberId() : null;
-
         boolean isAuthor = (currentMemberId != null && authorId != null && currentMemberId.equals(authorId));
 
-        return BoardResponse.fromEntity(board,board.getContent(),isAuthor);
+        List<BoardHashtagEntity> boardHashtags = boardHashtagRepository.findAllByBoardId(id);
+        List<String> tags = boardHashtags.stream()
+                .map(bh -> bh.getHashtag().getName())
+                .toList();
+
+        return BoardResponse.fromEntity(board,tags,board.getContent(),isAuthor);
     }
 
     @Override


### PR DESCRIPTION
해시태그 기능
---

- [x] ERD 설계: HASHTAG(태그 정보), BOARD_HASHTAG(매핑 테이블) 테이블 및 시퀀스 생성

- [x] Entity 구현:

HashtagEntity, BoardHashtagEntity 클래스 생성

BoardEntity에 boardHashtags 양방향 매핑 추가 (@OneToMany)

- [x] DTO 수정: BoardRequestDTO, BoardResponse에 List<String> tags 필드 추가 및 변환 메서드 수정

- [x] Repository 구현:

HashtagRepository: 태그명 중복 확인 및 조회

BoardHashtagRepository: 게시글 ID 기준 태그 조회 및 삭제 (@Query로 필드 매핑 명시)

- [x] Service 로직 구현 (BoardServiceImpl):

saveHashtags: 태그 존재 여부 확인 후 저장 (Get-or-Create)

게시글 작성(saveNewBoard) 및 수정(updateBoard) 시 태그 저장/갱신 로직 적용

게시글 상세 조회(findBoardById) 시 태그 목록 포함 반환

검색 기능
---
- [x] Repository 쿼리 작성:

BoardRepository에 제목+내용(LIKE) 및 해시태그 필터링 검색 쿼리 구현

Oracle CLOB 타입 DISTINCT 오류 해결을 위해 쿼리에서 DISTINCT 제거

- [x] Service 로직 구현 (BoardServiceImpl):

검색어 와일드카드(%) 처리

Java Stream API의 .distinct()를 사용하여 검색 결과 중복 제거

- [x] Controller 구현:

BoardRestController에 /api/v1/boards/search 엔드포인트 추가

keyword(검색어), tag(해시태그) 파라미터 처리

- [x] Security 설정: SecurityConfig에 검색 API 경로(permitAll) 접근 권한 허용