### PR TITLE
[feat/#13] 대댓글 기능 구현

### DIFF
--- a/blog/blog/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/blog/blog/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -25,89 +25,109 @@ import java.util.Collections;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
-    // ⭐ 1. CorsConfigurationSource Bean 정의: CORS 설정을 Security Filter에 명시적으로 주입합니다.
 
+    // 1. CORS 설정 Bean
     @Bean
     @Order(0)
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        // 임시 ip 등록
+        // 허용할 출처 목록 (프론트엔드 주소들)
         configuration.setAllowedOrigins(Arrays.asList(
                 "http://localhost:5173",
-                "http://172.30.1.9:5500",
+                "http://127.0.0.1:5500",
                 "http://localhost:5500",
+                "http://172.30.1.9:5500",
                 "http://192.168.0.8:5500",
                 "http://192.168.0.28:5500",
-                "http://127.0.0.1:5500",
                 "http://192.168.0.3:5500",
                 "http://192.168.0.13:5500"
-
         ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Collections.singletonList("*"));
         configuration.setAllowCredentials(true);
 
-        // 경로 "/api/v1/**"에 이 CORS 설정을 적용합니다.
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/api/v1/**", configuration);
         return source;
     }
 
+    // 2. Security Filter Chain 설정
     @Bean
-    @Order(1)// 우선순위를 높이는
-    public SecurityFilterChain securityFilterChain(HttpSecurity http,  JwtAuthenticationFilter jwtFilter) throws Exception {
+    @Order(1)
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter) throws Exception {
         http
-                // CORS 설정을 커스터마이징된 corsConfigurationSource Bean으로 적용
-                .cors(cors ->cors.configurationSource(corsConfigurationSource()))
-                // 1. **핵심 설정**: API 경로는 인증 없이 접근 가능하도록 허용 (API 공개)
+                // 기본 설정 (CORS, CSRF, 세션 등)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 3. API 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.GET,"/api/v1/subscriptions/**").permitAll()
-                        .requestMatchers(HttpMethod.POST,"/api/v1/subscriptions/**").authenticated()
-                        .requestMatchers("/api/v1/notifications/subscribe").authenticated()
+                        // ========================================================
+                        // [GROUP 1] 정적 자원 및 문서 (누구나 접근 가능)
+                        // ========================================================
+                        .requestMatchers(
+                                "/swagger-ui/**", "/v3/api-docs/**", "/index.html", "/",
+                                "/images/**", "/upload/**", "/board.html"
+                        ).permitAll()
+
+                        // ========================================================
+                        // [GROUP 2] 회원가입, 로그인, OAuth (누구나 접근 가능)
+                        // ========================================================
+                        .requestMatchers(
+                                "/api/v1/login",
+                                "/api/v1/member",          // 회원가입
+                                "/api/v1/check/**",        // 중복 체크
+                                "/login/oauth2/code/kakao",// 카카오 리다이렉트
+                                "/api/v1/oauth/kakao/url"  // 카카오 인증 URL
+                        ).permitAll()
+
+                        // ========================================================
+                        // [GROUP 3] 인증이 '필수'인 기능 (Authenticated) - 먼저 선언!
+                        // ========================================================
+
+                        // 3-1. 게시글 쓰기/수정/삭제/이미지업로드/좋아요
+                        .requestMatchers(HttpMethod.POST, "/api/v1/boards").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/boards/upload-image").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/boards/**").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/boards/**").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/boards/*/like").authenticated() // 게시글 좋아요
+
+                        // 3-2. 댓글 및 대댓글 (작성/수정/삭제/좋아요)
+                        .requestMatchers(HttpMethod.POST, "/api/v1/boards/*/comments").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/boards/*/comments/*").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/boards/*/comments/*").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/boards/*/comments/*/like").authenticated() // 댓글 좋아요
+
+                        // 3-3. 알림 및 구독 (쓰기 작업)
+                        .requestMatchers("/api/v1/notifications/**").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/subscriptions/**").authenticated()
+
+                        // 3-4. 테스트용 (필요시 제거)
                         .requestMatchers("/api/v1/test/**").authenticated()
-                        .requestMatchers("/api/v1/boards/auth-check").permitAll()
-                        .requestMatchers("/api/v1/boards/{boardId}/like").authenticated()
-                        .requestMatchers(HttpMethod.POST,"/api/v1/boards/markdown-preview").permitAll()
-                        .requestMatchers(HttpMethod.GET,"/api/v1/boards/{boardId}").permitAll()
-                        .requestMatchers(HttpMethod.GET,"/api/v1/boards/{boardId}/**").permitAll()
-                        .requestMatchers("/api/v1/boards/search").permitAll()
-                        // 카카오 로그인 추가하기
-                        // 1. 카카오 Redirect URI (가장 중요한 부분)
-                        .requestMatchers("/login/oauth2/code/kakao").permitAll()
-                        // 2. 카카오 인증 시작 URL 요청 엔드포인트
-                        .requestMatchers("/api/v1/oauth/kakao/url").permitAll()
-                        .requestMatchers("/images/**").permitAll()
-                        .requestMatchers("/upload/**").permitAll()
-                        .requestMatchers("/upload/images/**").permitAll()
-                        // Swagger UI 및 정적 파일 경로도 허용 (필요할 경우)
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/index.html", "/").permitAll()
-                        .requestMatchers("/board.html").permitAll()
-                        .requestMatchers("/upload/images/**").permitAll()
-                        .requestMatchers("/api/v1/boards/cursor").permitAll()
-                        .requestMatchers("/api/v1/boards").permitAll()
-                        .requestMatchers("/api/v1/login", "/api/v1/member", "/api/v1/check/**").permitAll()
-                        // /api/v1/로 시작하는 모든 요청 허용
-                        // 이건 토큰 없이도 통과가 되는데 그래서 필터 돌아도 참조 안 해서 null일 수도 있음
-//                        .requestMatchers("/api/v1/**").permitAll()
-                        .requestMatchers("/api/v1/boards/upload-image").authenticated()
 
+                        // ========================================================
+                        // [GROUP 4] 조회 기능 (누구나 접근 가능) - 나중에 선언!
+                        // ========================================================
+                        // 위에서 POST, PUT, DELETE 등은 이미 authenticated()로 걸러졌으므로
+                        // 여기서 boards/** 를 permitAll 해도 안전하게 GET 요청만 통과되는 효과를 봅니다.
+                        .requestMatchers(HttpMethod.GET, "/api/v1/boards/**").permitAll() // 게시글 목록/상세 조회
+                        .requestMatchers("/api/v1/boards/search").permitAll()             // 검색
+                        .requestMatchers("/api/v1/boards/cursor").permitAll()             // 커서 페이징
+                        .requestMatchers(HttpMethod.POST, "/api/v1/boards/markdown-preview").permitAll() // 마크다운 미리보기
+                        .requestMatchers(HttpMethod.GET, "/api/v1/subscriptions/**").permitAll() // 구독 여부 조회
 
-                        .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요 (나머지 페이지 보호)
+                        // ========================================================
+                        // [GROUP 5] 그 외 모든 요청
+                        // ========================================================
+                        .anyRequest().authenticated()
                 )
 
-                // 2. REST API를 위한 설정: CSRF 토큰 비활성화 (프론트엔드 분리 시 필요)
-                .csrf(AbstractHttpConfigurer::disable)
-
-                // 3. API 서버이므로 기본 로그인 페이지와 HTTP Basic 인증 비활성화
-                .formLogin(AbstractHttpConfigurer::disable)
-
-                // 4. **HTTP Basic 인증 비활성화**: 팝업 창이 뜨는 것을 확실히 방지
-                .httpBasic(AbstractHttpConfigurer::disable)
-
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
-                // 5. **세션 관리 설정 추가**: REST API 서버는 세션을 사용하지 않으므로 Stateless 설정
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+                // JWT 필터 추가
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/blog/blog/src/main/java/com/example/demo/controller/board/BoardCommentController.java
+++ b/blog/blog/src/main/java/com/example/demo/controller/board/BoardCommentController.java
@@ -3,11 +3,13 @@ package com.example.demo.controller.board;
 import com.example.demo.dto.board.CommentRequestDTO;
 import com.example.demo.dto.board.CommentResponseDTO;
 import com.example.demo.service.board.BoardCommentService;
+import com.example.demo.service.member.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -31,6 +33,7 @@ public class BoardCommentController {
     @PostMapping
     public ResponseEntity<CommentResponseDTO> createComment(
             @PathVariable Long boardId , @Valid @RequestBody CommentRequestDTO requestDTO){
+
         log.info("댓글 작성 요청- boardId :{}, content : {}",boardId,requestDTO.getContent());
         try{
             CommentResponseDTO response = commentService.createComment(boardId,requestDTO);

--- a/blog/blog/src/main/java/com/example/demo/dto/board/CommentRequestDTO.java
+++ b/blog/blog/src/main/java/com/example/demo/dto/board/CommentRequestDTO.java
@@ -11,4 +11,6 @@ public class CommentRequestDTO {
     @Size(max = 500,message = "댓글은 500자를 초과할 수 없습니다.")
     private String content;
 
+    private Long parentId;
+
 }

--- a/blog/blog/src/main/java/com/example/demo/dto/board/CommentResponseDTO.java
+++ b/blog/blog/src/main/java/com/example/demo/dto/board/CommentResponseDTO.java
@@ -1,11 +1,13 @@
 package com.example.demo.dto.board;
 
+import com.example.demo.entity.board.BoardCommentEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @Builder
@@ -23,4 +25,23 @@ public class CommentResponseDTO {
     private String nickname;
     private Boolean isAuthor;
     private Boolean isLikedByCurrentUser;
+
+    private List<CommentResponseDTO> children;
+
+    public static CommentResponseDTO fromEntity(BoardCommentEntity entity, Long currentMemberId){
+        boolean isAuthor = (currentMemberId != null) && entity.getMember().getMemberId() == currentMemberId;
+
+        List<CommentResponseDTO> childDTOs = entity.getChildren().stream()
+                .map(child -> fromEntity(child,currentMemberId))
+                .toList();
+
+        return CommentResponseDTO.builder()
+                .commentId(entity.getCommentId())
+                .content(entity.getContent())
+                .nickname(entity.getMember().getNickname())
+                .inputDate(entity.getInputDate())
+                .isAuthor(isAuthor)
+                .children(childDTOs)
+                .build();
+    }
 }

--- a/blog/blog/src/main/java/com/example/demo/entity/board/BoardCommentEntity.java
+++ b/blog/blog/src/main/java/com/example/demo/entity/board/BoardCommentEntity.java
@@ -3,8 +3,11 @@ package com.example.demo.entity.board;
 import com.example.demo.entity.member.MemberEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -25,6 +28,7 @@ public class BoardCommentEntity {
 
     @Column(name = "input_date",nullable = false)
     private LocalDateTime inputDate;
+
     @Column(name = "modified_date")
     private LocalDateTime modifiedDate;
 
@@ -43,6 +47,16 @@ public class BoardCommentEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id",nullable = false)
     private BoardEntity board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private BoardCommentEntity parent;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "parent",orphanRemoval = true)
+    @OrderBy("inputDate ASC, commentId ASC")
+    @BatchSize(size = 100)
+    private List<BoardCommentEntity> children = new ArrayList<>();
 
 
     @PrePersist

--- a/blog/blog/src/main/java/com/example/demo/repository/board/BoardCommentRepository.java
+++ b/blog/blog/src/main/java/com/example/demo/repository/board/BoardCommentRepository.java
@@ -21,4 +21,12 @@ public interface BoardCommentRepository extends JpaRepository<BoardCommentEntity
             "WHERE c.commentId = :commentId " +
             "AND c.deleted = false")
     Optional<BoardCommentEntity> findByCommentIdAndDeletedFalse(@Param("commentId") Long commentId);
+
+
+    @Query("SELECT c FROM BoardCommentEntity c " +
+            "WHERE c.board.boardId = :boardId " +
+            "AND c.parent IS NULL " +
+            "AND c.deleted = false " +
+            "ORDER BY c.inputDate DESC, c.commentId DESC")
+    List<BoardCommentEntity> findRootCommentsByBoardId(@Param("boardId") Long boardId);
 }

--- a/blog/blog/src/main/java/com/example/demo/service/board/BoardCommentImpl.java
+++ b/blog/blog/src/main/java/com/example/demo/service/board/BoardCommentImpl.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -26,7 +27,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Slf4j
-public class BoardCommentImpl implements BoardCommentService{
+public class BoardCommentImpl implements BoardCommentService {
 
     private final BoardCommentRepository commentRepository;
     private final BoardRepository boardRepository;
@@ -34,9 +35,9 @@ public class BoardCommentImpl implements BoardCommentService{
     private final CommentLikeRepository commentLikeRepository;
     private final NotificationService notificationService;
 
-    private MemberEntity getCurrentMember(){
+    private MemberEntity getCurrentMember() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if(authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())){
+        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
             return null;
         }
         String username = authentication.getName();
@@ -46,72 +47,86 @@ public class BoardCommentImpl implements BoardCommentService{
 
     @Override
     public List<CommentResponseDTO> getCommentList(Long boardId) {
-
         MemberEntity currentMember = getCurrentMember();
 
-        List<BoardCommentEntity> comments = commentRepository.findByBoardIdAndNotDeleted(boardId);
+        List<BoardCommentEntity> comments = commentRepository.findRootCommentsByBoardId(boardId);
 
-        return comments.stream().map(comment -> convertToDTO(comment,currentMember)).collect(Collectors.toList());
+        List<BoardCommentEntity> sortedComments = comments.stream()
+                .sorted(Comparator.comparing(BoardCommentEntity::getCommentId).reversed())
+                .toList();
+
+        if (!sortedComments.isEmpty()) {
+            log.info("ID 역순 정렬 후 첫번째 댓글 ID: {} (가장 큰 숫자여야 함)", sortedComments.get(0).getCommentId());
+        }
+
+        return sortedComments.stream()
+                .map(comment -> convertToDTO(comment, currentMember))
+                .collect(Collectors.toList());
     }
 
     @Override
     @Transactional
-    public CommentResponseDTO createComment(Long boardId, CommentRequestDTO requestDTO){
+    public CommentResponseDTO createComment(Long boardId, CommentRequestDTO requestDTO) {
         MemberEntity member = getCurrentMember();
-        if(member ==null){
+        if (member == null) {
             throw new IllegalStateException("로그인이 필요합니다.");
         }
-        BoardEntity board = boardRepository.findById(boardId).orElseThrow(()-> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+        BoardEntity board = boardRepository.findById(boardId).orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
 
-        BoardCommentEntity comment =BoardCommentEntity.builder()
+        BoardCommentEntity.BoardCommentEntityBuilder commentBulider = BoardCommentEntity.builder()
                 .content(requestDTO.getContent())
                 .board(board)
                 .member(member)
                 .deleted(false)
-                .likes(0)
-                .build();
-        BoardCommentEntity savedComment = commentRepository.save(comment);
+                .likes(0);
+        if (requestDTO.getParentId() != null) {
+            BoardCommentEntity parent = commentRepository.findById(requestDTO.getParentId())
+                    .orElseThrow(() -> new IllegalArgumentException("부모 댓글을 찾을 수 없습니다."));
+            commentBulider.parent(parent);
+        }
+        BoardCommentEntity savedComment = commentRepository.save(commentBulider.build());
 
         MemberEntity boardWriter = board.getMember();
-        if(boardWriter.getMemberId() != member.getMemberId()){
+        if (boardWriter.getMemberId() != member.getMemberId()) {
             notificationService.send(
-                    boardWriter,member.getNickname() + "님이 게시글에 댓글을 남겼습니다.",
-                    "/board/"+boardId
+                    boardWriter, member.getNickname() + "님이 게시글에 댓글을 남겼습니다.",
+                    "/board/" + boardId
             );
         }
-        return convertToDTO(savedComment,member);
+        return convertToDTO(savedComment, member);
     }
+
     @Override
     @Transactional
-    public CommentResponseDTO updateComment(Long boardId, Long commentId, CommentRequestDTO requestDTO){
+    public CommentResponseDTO updateComment(Long boardId, Long commentId, CommentRequestDTO requestDTO) {
         MemberEntity member = getCurrentMember();
 
-        if(member == null){
+        if (member == null) {
             throw new IllegalStateException("로그인이 필요합니다.");
         }
 
-        BoardCommentEntity comment = commentRepository.findByCommentIdAndDeletedFalse(commentId).orElseThrow(()-> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+        BoardCommentEntity comment = commentRepository.findByCommentIdAndDeletedFalse(commentId).orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
 
-        if(comment.getMember().getMemberId() != member.getMemberId()){
+        if (comment.getMember().getMemberId() != member.getMemberId()) {
             throw new IllegalStateException("댓글 수정 권한이 없습니다.");
         }
         comment.setContent(requestDTO.getContent());
 
         BoardCommentEntity updateComment = commentRepository.save(comment);
-        return convertToDTO(updateComment,member);
+        return convertToDTO(updateComment, member);
     }
 
     @Override
     @Transactional
-    public void deleteComment(Long boardId, Long commentId){
+    public void deleteComment(Long boardId, Long commentId) {
         MemberEntity member = getCurrentMember();
 
-        if(member == null){
+        if (member == null) {
             throw new IllegalStateException("로그인이 필요합니다.");
         }
-        BoardCommentEntity comment = commentRepository.findByCommentIdAndDeletedFalse(commentId).orElseThrow(()-> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
-        if(comment.getMember().getMemberId() != member.getMemberId()){
-            throw  new IllegalStateException("댓글 삭제 권한이 없습니다.");
+        BoardCommentEntity comment = commentRepository.findByCommentIdAndDeletedFalse(commentId).orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+        if (comment.getMember().getMemberId() != member.getMemberId()) {
+            throw new IllegalStateException("댓글 삭제 권한이 없습니다.");
         }
 
         comment.setDeleted(true);
@@ -121,32 +136,32 @@ public class BoardCommentImpl implements BoardCommentService{
 
     @Override
     @Transactional
-    public Boolean toggleLike(Long boardId, Long commentId){
+    public Boolean toggleLike(Long boardId, Long commentId) {
         MemberEntity member = getCurrentMember();
 
-        if(member == null){
+        if (member == null) {
             throw new IllegalStateException("로그인이 필요합니다.");
         }
-        BoardCommentEntity comment = commentRepository.findByCommentIdAndDeletedFalse(commentId).orElseThrow(()-> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+        BoardCommentEntity comment = commentRepository.findByCommentIdAndDeletedFalse(commentId).orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
 
-        Optional<CommentLikeEntity> existingLike = commentLikeRepository.findByCommentAndMember(comment,member);
+        Optional<CommentLikeEntity> existingLike = commentLikeRepository.findByCommentAndMember(comment, member);
 
-        if(existingLike.isPresent()){
+        if (existingLike.isPresent()) {
             commentLikeRepository.delete(existingLike.get());
-            comment.setLikes(Math.max(0,comment.getLikes() -1));
+            comment.setLikes(Math.max(0, comment.getLikes() - 1));
             return false;
-        } else{
+        } else {
             CommentLikeEntity like = CommentLikeEntity.builder()
                     .comment(comment)
                     .member(member)
                     .build();
             commentLikeRepository.save(like);
-            comment.setLikes(comment.getLikes()+1);
+            comment.setLikes(comment.getLikes() + 1);
 
             MemberEntity commentWriter = comment.getMember();
-            if(commentWriter.getMemberId() != member.getMemberId()){
+            if (commentWriter.getMemberId() != member.getMemberId()) {
                 notificationService.send(
-                        commentWriter,member.getNickname()+"님이 회원님의 댓글을 좋아합니다.","/board/"+boardId
+                        commentWriter, member.getNickname() + "님이 회원님의 댓글을 좋아합니다.", "/board/" + boardId
                 );
             }
             return true;
@@ -154,13 +169,20 @@ public class BoardCommentImpl implements BoardCommentService{
     }
 
 
-    private CommentResponseDTO convertToDTO(BoardCommentEntity comment, MemberEntity currentMember){
-        boolean isAuthor =currentMember != null && comment.getMember().getMemberId() == currentMember.getMemberId();
+    private CommentResponseDTO convertToDTO(BoardCommentEntity comment, MemberEntity currentMember) {
+        boolean isAuthor = currentMember != null && comment.getMember().getMemberId() == currentMember.getMemberId();
 
         boolean isLiked = false;
-        if(currentMember != null){
-            isLiked = commentLikeRepository.countByCommentAndMember(comment,currentMember) > 0;
+        if (currentMember != null) {
+            isLiked = commentLikeRepository.countByCommentAndMember(comment, currentMember) > 0;
         }
+
+
+        List<CommentResponseDTO> childDTOs = comment.getChildren().stream()
+                .filter(child -> !child.getDeleted())
+                .map(child -> convertToDTO(child, currentMember))
+                .toList();
+
         return CommentResponseDTO.builder()
                 .commentId(comment.getCommentId())
                 .content(comment.getContent())
@@ -172,6 +194,7 @@ public class BoardCommentImpl implements BoardCommentService{
                 .nickname(comment.getMember().getNickname())
                 .isAuthor(isAuthor)
                 .isLikedByCurrentUser(isLiked)
+                .children(childDTOs)
                 .build();
     }
 


### PR DESCRIPTION
Step 1: DB 스키마 변경 (Oracle)

- [x] board_comment 테이블에 parent_id 컬럼 추가

- [x]  parent_id에 Self Referencing 외래키(FK) 설정 ---

Step 2: Backend - Entity & Repository 수정

- [x] CommentEntity에 parent(ManyToOne), children(OneToMany) 필드 추가

- [x] CommentRepository에 최상위(부모가 null인) 댓글만 조회하는 메서드 추가 ---

Step 3: Backend - DTO & Service 로직 구현

- [x] CommentRequestDTO: 부모 ID(parentId) 필드 추가

- [x] CommentResponseDTO: 자식 댓글 목록(children) 필드 추가 및 변환 로직 작성

- [x]  CommentService: 대댓글 저장 및 계층형 조회 로직 구현