### PR TITLE
[feat/#15] 게시글 조회수 성능 최적화 및 동시성 처리 (Redis)

### DIFF
--- a/blog/blog/build.gradle
+++ b/blog/blog/build.gradle
@@ -51,6 +51,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'com.vladsch.flexmark:flexmark-all:0.64.8'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/blog/blog/src/main/java/com/example/demo/BlogApplication.java
+++ b/blog/blog/src/main/java/com/example/demo/BlogApplication.java
@@ -2,7 +2,9 @@ package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class BlogApplication {
 

--- a/blog/blog/src/main/java/com/example/demo/controller/board/BoardRestController.java
+++ b/blog/blog/src/main/java/com/example/demo/controller/board/BoardRestController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -125,12 +126,16 @@ public class BoardRestController {
     }
 
     @GetMapping("/{boardId}")
-    public ResponseEntity<BoardDetailResponse> detail(@PathVariable("boardId")Long boardId,@AuthenticationPrincipal CustomUserDetails details){
+    public ResponseEntity<BoardDetailResponse> detail(@PathVariable("boardId")Long boardId, @AuthenticationPrincipal CustomUserDetails details
+                                                        ,HttpServletRequest request){
 
         Long currentMemberId = (details != null)?details.getMemberId(): null;
 
         BoardEntity board = boardService.findBoardByIdExceptUser(boardId);
-        boardService.increaseView(boardId);
+
+        String clientIdentifier = (currentMemberId != null) ? String.valueOf(currentMemberId) : request.getRemoteAddr();
+
+        boardService.increaseView(boardId, clientIdentifier);
 
         Long authorId = board.getMember().getMemberId();
         boolean isAuthor = (currentMemberId != null) && currentMemberId.equals(authorId);

--- a/blog/blog/src/main/java/com/example/demo/dto/board/BoardResponse.java
+++ b/blog/blog/src/main/java/com/example/demo/dto/board/BoardResponse.java
@@ -1,9 +1,7 @@
 package com.example.demo.dto.board;
 
 import com.example.demo.entity.board.BoardEntity;
-
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 
@@ -12,63 +10,67 @@ public record BoardResponse(
         String title,
         String contentSummary,
         String nickname,
-        String filePath,
+        String filePath, // 💡 DB의 원본 파일명
         String fileOriginalName,
         Long fileSize,
         LocalDateTime inputDate,
         LocalDateTime modifiedDate,
-        String content,
+        String content, // 💡 리스트 조회시는 null
         int likes,
         int views,
         String category,
         List<String> tags,
-
         Boolean isAuthor
 ) {
     private static final String SERVER_BASE_URL = "http://localhost:8000";
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yy-MM-dd HH:mm:ss");
 
-    // =========================================================================
-    // 💡 1. 오버로딩 메서드 추가 (List.stream().map()에서 사용)
-    // =========================================================================
-    // 1-1 태그가 없는 경우(기존 코드 호환용, 빈 리스트 처리)
-    public static BoardResponse fromEntity(BoardEntity entity, boolean isAuthor) {
-        // 목록 조회 시 엔티티의 Content를 그대로 사용하도록 합니다.
-        // 상세 조회 시에만 contentOverride를 사용하므로, 이 경우 null을 전달하여 엔티티의 내용을 사용하도록 위임합니다.
-        // 또는 contentOverride를 'Optional'로 만들어서 처리할 수 있지만, 여기서는 단순하게 entity.getContent()를 전달합니다.
-        return fromEntity(entity, Collections.emptyList(),entity.getContentSummary(),isAuthor);
-    }
-    //1-2 태그가 있는 경우
-    public static BoardResponse fromEntity(BoardEntity entity, List<String> tags,boolean isAuthor){
-        return fromEntity(entity,tags,entity.getContentSummary(),isAuthor);
-    }
-    //1-3 메인 변환 로직(내용 요약/전체구분 + 태그포함)
-    public static BoardResponse fromEntity(BoardEntity entity,List<String> tags,String contentOverrideOrSummary, boolean isAuthor){
-        String webFilePath = null;
-
-        if(entity.getFilePath() !=null && !entity.getFilePath().isEmpty()) {
-            String fileName = entity.getFilePath().substring(entity.getFilePath().lastIndexOf("\\") + 1);
-            webFilePath = SERVER_BASE_URL+"/upload/" + fileName;
+    // ✅ [핵심] 컴팩트 생성자
+    // JPQL 조회(new BoardResponse...)와 fromEntity 모두 이 로직을 거칩니다.
+    public BoardResponse {
+        // 이미지 경로 변환 로직
+        if (filePath != null && !filePath.isEmpty() && !filePath.startsWith("http")) {
+            String fileName = filePath.substring(filePath.lastIndexOf("\\") + 1);
+            filePath = SERVER_BASE_URL + "/upload/" + fileName;
         }
 
-        return  new BoardResponse(
+        // 태그 null 방지
+        if (tags == null) {
+            tags = Collections.emptyList();
+        }
+    }
+
+    // =========================================================================
+    // 💡 기존 서비스 코드 호환용 오버로딩 메서드들 (이게 없어서 에러가 났던 것!)
+    // =========================================================================
+
+    // 1. (Entity, Tags, Summary, isAuthor) - 4개 인자 받는 버전 (에러 해결용)
+    public static BoardResponse fromEntity(BoardEntity entity, List<String> tags, String summary, boolean isAuthor) {
+        return new BoardResponse(
                 entity.getBoardId(),
                 entity.getTitle(),
-                contentOverrideOrSummary,
+                summary, // 전달받은 요약 사용
                 entity.getNickname(),
-                webFilePath,
+                entity.getFilePath(),
                 entity.getFileOriginalName(),
                 entity.getFileSize(),
-                entity.getInputDate() !=null ? entity.getInputDate() : LocalDateTime.now(),
-                entity.getModifiedDate() !=null ? entity.getInputDate() : LocalDateTime.now(),
+                entity.getInputDate() != null ? entity.getInputDate() : LocalDateTime.now(),
+                entity.getModifiedDate() != null ? entity.getModifiedDate() : LocalDateTime.now(),
                 entity.getContent(),
                 entity.getLikes(),
                 entity.getViews(),
                 entity.getCategory(),
-                tags != null ? tags : Collections.emptyList(),
+                tags,
                 isAuthor
-
         );
     }
 
+    // 2. (Entity, Tags, isAuthor) - 3개 인자 버전
+    public static BoardResponse fromEntity(BoardEntity entity, List<String> tags, boolean isAuthor) {
+        return fromEntity(entity, tags, entity.getContentSummary(), isAuthor);
+    }
+
+    // 3. (Entity, isAuthor) - 2개 인자 버전 (태그 없을 때)
+    public static BoardResponse fromEntity(BoardEntity entity, boolean isAuthor) {
+        return fromEntity(entity, Collections.emptyList(), entity.getContentSummary(), isAuthor);
+    }
 }

--- a/blog/blog/src/main/java/com/example/demo/repository/board/BoardRepository.java
+++ b/blog/blog/src/main/java/com/example/demo/repository/board/BoardRepository.java
@@ -1,6 +1,8 @@
 package com.example.demo.repository.board;
 
+import com.example.demo.dto.board.BoardResponse;
 import com.example.demo.entity.board.BoardEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,15 +16,35 @@ public interface BoardRepository extends JpaRepository<BoardEntity,Long> {
     @Query(value = "SELECT b FROM board b JOIN FETCH b.member ORDER BY b.board_id DESC",nativeQuery = true)
     List<BoardEntity> findAllWithMember();
 
-    @Modifying
-    @Query(value = "update board set views = views + 1 where board_id =  :boardId",nativeQuery = true)
-    void increaseView(@Param("boardId") Long boardId);
+//    @Modifying
+//    @Query(value = "update board set views = views + 1 where board_id =  :boardId",nativeQuery = true)
+//    void increaseView(@Param("boardId") Long boardId);
 
 
-    @Query("SELECT b FROM BoardEntity b JOIN FETCH b.member " +
-            "WHERE (:cursorId IS NULL OR b.boardId < :cursorId) AND b.inputDate <= :cursorDate " +
-            "ORDER BY b.inputDate DESC, b.boardId DESC")
-    List<BoardEntity> findNextBoardsWithMember(@Param("cursorId") Long cursorId, @Param("cursorDate") LocalDateTime cursorDate, @Param("pageSize")int pageSize);
+    @Query(value = """
+        SELECT * FROM (
+            SELECT 
+                b.board_id AS boardId, 
+                b.title, 
+                b.content_summary AS contentSummary, 
+                m.nickname, 
+                b.file_path AS filePath, 
+                b.file_original_name AS fileOriginalName, 
+                b.file_size AS fileSize, 
+                b.input_date AS inputDate, 
+                b.modified_date AS modifiedDate, 
+                b.views, 
+                b.likes, 
+                b.category
+            FROM board b
+            JOIN member m ON b.member_id = m.member_id
+            WHERE (:cursorDate IS NULL OR b.input_date < :cursorDate OR (b.input_date = :cursorDate AND b.board_id < :cursorId))
+            ORDER BY b.input_date DESC, b.board_id DESC
+        ) WHERE ROWNUM <= :limitSize
+    """, nativeQuery = true)
+    List<BoardSummary> findBoardListNative(@Param("cursorId") Long cursorId,
+                                           @Param("cursorDate") LocalDateTime cursorDate,
+                                           @Param("limitSize") int limitSize);
 
     @Query("SELECT b FROM BoardEntity b " +
             "LEFT JOIN FETCH b.member m " +
@@ -32,4 +54,10 @@ public interface BoardRepository extends JpaRepository<BoardEntity,Long> {
             "AND (:tagName IS NULL OR h.name = :tagName) " +
             "ORDER BY b.inputDate DESC")
     List<BoardEntity> searchBoards(@Param("keyword") String keyword, @Param("tagName") String tagName);
+
+
+
+    @Modifying
+    @Query("UPDATE BoardEntity b SET b.views = b.views + :increment WHERE b.boardId = :boardId")
+    void addViews(@Param("boardId") long boardId, @Param("increment") long increment);
 }

--- a/blog/blog/src/main/java/com/example/demo/repository/board/BoardSummary.java
+++ b/blog/blog/src/main/java/com/example/demo/repository/board/BoardSummary.java
@@ -1,0 +1,21 @@
+package com.example.demo.repository.board;
+
+
+import java.time.LocalDateTime;
+
+public interface BoardSummary {
+
+    Long getBoardId();
+    String getTitle();
+    String getContentSummary();
+    String getNickname();
+    String getFilePath();
+    String getFileOriginalName();
+    Long getFileSize();
+    LocalDateTime getInputDate();
+    LocalDateTime getModifiedDate();
+    Integer getViews();
+    Integer getLikes();
+    String getCategory();
+
+}

--- a/blog/blog/src/main/java/com/example/demo/scheduler/ViewCountScheduler.java
+++ b/blog/blog/src/main/java/com/example/demo/scheduler/ViewCountScheduler.java
@@ -1,0 +1,48 @@
+package com.example.demo.scheduler;
+
+import com.example.demo.repository.board.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ViewCountScheduler {
+
+    private final RedisTemplate<String,String> redisTemplate;
+    private final BoardRepository boardRepository;
+
+    @Scheduled(fixedDelay = 180000)
+    @Transactional
+    public void syncViewCounts(){
+        Set<String> boardIds = redisTemplate.opsForSet().members("view:changed_boards");
+
+        if(boardIds == null || boardIds.isEmpty()){
+            return;
+        }
+
+        log.info("조회수 동기화 시작 : 총 {}건",boardIds.size());
+
+        for(String boardIdStr : boardIds){
+            String countKey = "view:count:"+boardIdStr;
+            String countVal = redisTemplate.opsForValue().get(countKey);
+
+            if(countVal != null){
+                long boardId = Long.parseLong(boardIdStr);
+                long increment = Long.parseLong(countVal);
+
+                boardRepository.addViews(boardId,increment);
+
+                redisTemplate.delete(countKey);
+                redisTemplate.opsForSet().remove("view:changed_boards",boardIdStr);
+            }
+        }
+        log.info("조회수 동기화 완료");
+    }
+}

--- a/blog/blog/src/main/java/com/example/demo/service/board/BoardRedisService.java
+++ b/blog/blog/src/main/java/com/example/demo/service/board/BoardRedisService.java
@@ -1,0 +1,5 @@
+package com.example.demo.service.board;
+
+public interface BoardRedisService {
+    void increaseViewCount(Long boardId, String clientIdentifier);
+}

--- a/blog/blog/src/main/java/com/example/demo/service/board/BoardRedisServiceImpl.java
+++ b/blog/blog/src/main/java/com/example/demo/service/board/BoardRedisServiceImpl.java
@@ -1,0 +1,36 @@
+package com.example.demo.service.board;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class BoardRedisServiceImpl implements BoardRedisService{
+
+    private final RedisTemplate<String,String> redisTemplate;
+
+    @Override
+    public void increaseViewCount(Long boardId, String clientIdentifier) {
+        // 중복 조회 방지 키
+        String logKey = "view:log:" + boardId+ ":" + clientIdentifier;
+
+        // 조회수 카운트 키
+        String countKey = "view:count:" + boardId;
+
+        //중복 조회가 아니라면
+        if(!redisTemplate.hasKey(logKey)){
+
+            //조회수 증가
+            redisTemplate.opsForValue().increment(countKey);
+
+            //변경된 게시글 id를 Set에 저장(스케줄러 db 반영 위함)
+            redisTemplate.opsForSet().add("view:changed_boards",String.valueOf(boardId));
+
+            //중복 방지 로그 저장(24시간 유지, 하루에 1번 카운트)
+            redisTemplate.opsForValue().set(logKey,"1", Duration.ofHours(24));
+        }
+    }
+}

--- a/blog/blog/src/main/java/com/example/demo/service/board/BoardService.java
+++ b/blog/blog/src/main/java/com/example/demo/service/board/BoardService.java
@@ -25,7 +25,7 @@ public interface BoardService {
 
     void deleteBoard(Long boardId, Long currentMemberId) throws AccessDeniedException;
 
-    void increaseView(Long boardId);
+    void increaseView(Long boardId, String clientIdentifier);
 
     BoardListResponse getBoardsWithCursor(int size, Long cursorId, LocalDateTime cursorDate,Long currentMemberId);
 

--- a/blog/blog/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
+++ b/blog/blog/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
@@ -9,6 +9,7 @@ import com.example.demo.entity.board.HashtagEntity;
 import com.example.demo.entity.member.MemberEntity;
 import com.example.demo.repository.board.BoardHashtagRepository;
 import com.example.demo.repository.board.BoardRepository;
+import com.example.demo.repository.board.BoardSummary;
 import com.example.demo.repository.board.HashtagRepository;
 import com.example.demo.repository.member.MemberRepository;
 import com.example.demo.service.file.FileService;
@@ -20,6 +21,9 @@ import com.vladsch.flexmark.util.data.MutableDataSet;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -52,6 +56,9 @@ public class BoardServiceImpl implements BoardService {
     private static final MutableDataSet OPTIONS = new MutableDataSet();
     private static final Parser MARKDOWN_PARSER = Parser.builder(OPTIONS).build();
     private static final HtmlRenderer HTML_RENDERER = HtmlRenderer.builder(OPTIONS).build();
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final BoardRedisService redisService;
 
     @Value("${upload.file.path}")
     private String uploadDir;
@@ -274,62 +281,67 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     @Transactional
-    public void increaseView(Long boardId) {
-        boardRepository.increaseView(boardId);
+    public void increaseView(Long boardId, String clientIdentifier) {
+        redisService.increaseViewCount(boardId,clientIdentifier);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public BoardListResponse getBoardsWithCursor(int size, Long cursorId, LocalDateTime cursorDate,Long currentMemberId) {
+    public BoardListResponse getBoardsWithCursor(int size, Long cursorId, LocalDateTime cursorDate, Long currentMemberId) {
 
-        // 1. 요청된 크기보다 하나 더 가져와서 다음 페이지 존재 여부 확인 (size + 1)
-        int pageSize = size + 1;
-
-        if(cursorDate == null){
+        if (cursorDate == null) {
             cursorDate = LocalDateTime.now();
-            log.info("첫 페이지 조회: cursorDate를 현재 시간({})으로 설정했습니다. CursorId: {}", cursorDate, cursorId);
         }
-        // ⭐ 1. Repository는 BoardEntity 목록을 반환해야 합니다. (Service에서 DTO 변환)
-        // boards는 size + 1개의 Entity를 포함합니다.
-        List<BoardEntity> boards = boardRepository.findNextBoardsWithMember(cursorId, cursorDate,pageSize);
 
-        // 2. 다음 페이지 존재 여부 판단
-        boolean hasNext = boards.size() > size;
+        // 1. 오라클 11g 호환 네이티브 쿼리 호출 (size + 1개 요청)
+        int limitSize = size + 1;
+        List<BoardSummary> summaryList = boardRepository.findBoardListNative(cursorId, cursorDate, limitSize);
 
-        // 3. 실제 표시할 게시글 목록 (요청된 크기까지만)
-        // boards는 size + 1개이므로, subList(0, size)를 통해 size개만 contentEntities에 담깁니다.
-        List<BoardEntity> contentEntities = hasNext ? boards.subList(0, size) : boards;
+        // 2. 다음 페이지 존재 여부 확인
+        boolean hasNext = false;
+        if (summaryList.size() > size) {
+            hasNext = true;
+            summaryList.remove(size); // 마지막 확인용 1개 제거
+        }
 
-        // 4. Entity를 DTO로 변환
-        List<BoardResponse> contentDtos = contentEntities.stream()
-                .map(entity -> {
-                    Long authorId = (entity.getMember() != null) ? entity.getMember().getMemberId() : null;
-                            boolean isAuthor = (currentMemberId != null && authorId != null && currentMemberId.equals(authorId));
-                            return BoardResponse.fromEntity(entity,Collections.emptyList(), entity.getContentSummary(), isAuthor);
-                        })
-                .collect(Collectors.toList());
-        // 5. 다음 커서 값 설정
+        // 3. BoardSummary -> BoardResponse 변환
+        // (DTO 생성자를 호출하면 이미지 경로 변환 로직이 자동 실행됨)
+        List<BoardResponse> boardResponses = summaryList.stream()
+                .map(s -> new BoardResponse(
+                        s.getBoardId(),
+                        s.getTitle(),
+                        s.getContentSummary(),
+                        s.getNickname(),
+                        s.getFilePath(),
+                        s.getFileOriginalName(),
+                        s.getFileSize(),
+                        s.getInputDate(),
+                        s.getModifiedDate(),
+                        null, // content (리스트에선 안 씀)
+                        s.getViews(),
+                        s.getLikes(),
+                        s.getCategory(),
+                        null, // tags
+                        false // isAuthor
+                ))
+                .toList();
+
+        // 4. 다음 커서 계산
         Long nextCursorId = null;
         LocalDateTime nextCursorDate = null;
 
-        if (hasNext) {
-            // ⭐ 2. 커서 추출 로직 수정:
-            // 커서는 Repository에서 가져온 전체 목록(boards) 중
-            // 현재 페이지에 표시되지 않은 다음 항목 (인덱스 size)에서 추출해야 합니다.
-            BoardEntity cursorEntity = boards.get(size);
-
-            nextCursorId = cursorEntity.getBoardId();
-            nextCursorDate = cursorEntity.getInputDate();
+        if (!boardResponses.isEmpty()) {
+            BoardResponse lastBoard = boardResponses.get(boardResponses.size() - 1);
+            nextCursorId = lastBoard.boardId();
+            nextCursorDate = lastBoard.inputDate();
         }
 
-        // BoardListResponse DTO로 반환
         return new BoardListResponse(
-                contentDtos,
+                boardResponses,
                 hasNext,
                 nextCursorId,
                 nextCursorDate
         );
-
     }
 
     @Override

--- a/blog/blog/src/test/java/com/example/demo/controller/board/ViewCountConcurrencyTest.java
+++ b/blog/blog/src/test/java/com/example/demo/controller/board/ViewCountConcurrencyTest.java
@@ -1,0 +1,67 @@
+package com.example.demo.controller.board;
+
+import com.example.demo.service.board.BoardRedisService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class ViewCountConcurrencyTest {
+
+    @Autowired
+    private BoardRedisService boardRedisService;
+    @Autowired
+    private RedisTemplate<String,String> redisTemplate;
+
+    @AfterEach
+    void tearDown(){
+        redisTemplate.execute((RedisCallback<Object>) connection -> {
+            connection.serverCommands().flushAll();
+            return null;
+        });
+    }
+
+    @Test
+    @DisplayName("100명이 동시에 조회했을 때 조회수가 100개 올라가야 한다.")
+    void view_count_concurrency_test() throws InterruptedException {
+
+        int threadCount = 100;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        Long boarId = 1L;
+
+        for(int i = 0; i<threadCount; i++){
+            String userIp = "192.168.0."+i;
+
+            executorService.submit(()->{
+                try{
+                    boardRedisService.increaseViewCount(boarId,userIp);
+                }finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        String countKey = "view:count:"+boarId;
+        String viewCount = redisTemplate.opsForValue().get(countKey);
+
+        System.out.println("최종 조회수:"+viewCount);
+
+        assertThat(viewCount).isNotNull();
+        assertThat(Integer.parseInt(viewCount)).isEqualTo(threadCount);
+    }
+}


### PR DESCRIPTION
- build.gradle Redis 의존성 추가 및 설정
- RedisUtil (또는 Service) 구현: 조회수 증가(incr) 및 중복 방지 로직
- 어뷰징 방지 로직: 동일 IP/User의 경우 24시간 내 1회만 카운트 (Redis TTL 활용)
- Spring Scheduler 구현: 일정 주기로 Redis → DB 동기화 로직 작성
-  DB 반영 최적화: 변경된 게시글만 선별하여 Bulk Update 또는 단건 Update 처리
- 동시성 테스트 및 로그 확인