### PR TITLE
[feat/#25] 구글 OAuth2 소셜 로그인 구현

### DIFF
--- a/blog/blog/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/blog/blog/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
                 "http://192.168.0.28:5500",
                 "http://192.168.0.3:5500",
                 "http://192.168.0.13:5500",
-                "http://localhost:3000"
+                "http://localhost:3000",
+                "https://accounts.google/com"
         ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Collections.singletonList("*"));
@@ -50,6 +51,7 @@ public class SecurityConfig {
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/api/v1/**", configuration);
+        source.registerCorsConfiguration("/login/oauth2/**",configuration);
         return source;
     }
 
@@ -72,7 +74,7 @@ public class SecurityConfig {
                         // ========================================================
                         .requestMatchers(
                                 "/swagger-ui/**", "/v3/api-docs/**", "/index.html", "/",
-                                "/images/**", "/upload/**", "/board.html"
+                                "/images/**", "/upload/**", "/board.html","/error"
                         ).permitAll()
 
                         // ========================================================
@@ -83,10 +85,14 @@ public class SecurityConfig {
                                 "/api/v1/member",          // 회원가입
                                 "/api/v1/check/**",        // 중복 체크
                                 "/login/oauth2/code/kakao",// 카카오 리다이렉트
-                                "/api/v1/oauth/kakao/url"  // 카카오 인증 URL
+                                "/api/v1/oauth/kakao/url",  // 카카오 인증 URL
+                                "/api/v1/oauth/google/url", // 구글 인증 URL
+                                "/login/oauth2/code/google" // 구글 리다이렉트
+
                         ).permitAll()
 
                         .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers("/api/v1/notifications/subscribe").permitAll()
 
                         // ========================================================
                         // [GROUP 3] 인증이 '필수'인 기능 (Authenticated) - 먼저 선언!

--- a/blog/blog/src/main/java/com/example/demo/controller/member/GoogleController.java
+++ b/blog/blog/src/main/java/com/example/demo/controller/member/GoogleController.java
@@ -1,0 +1,44 @@
+package com.example.demo.controller.member;
+
+import com.example.demo.service.member.GoogleOAuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class GoogleController {
+
+    private final GoogleOAuthService googleOAuthService;
+
+    @GetMapping("/api/v1/oauth/google/url")
+    public ResponseEntity<Map<String,String>> getGoogleAuthUrl(){
+        return ResponseEntity.ok(
+                Map.of("googleAuthUrl", googleOAuthService.getGoogleAuthUrl())
+        );
+    }
+
+    @GetMapping("/login/oauth2/code/google")
+    public ResponseEntity<?> googleCallback(@RequestParam("code") String code){
+        try{
+            String redirectUrl = googleOAuthService.processLoginAndGetRedirectUrl(code);
+            return ResponseEntity.status(HttpStatus.FOUND)
+                    .header(HttpHeaders.LOCATION,redirectUrl)
+                    .build();
+        } catch (Exception e){
+            log.error("[Google OAuth] 로그인 처리 중 오류 발생 -message: {}",e.getMessage(),e);
+            return ResponseEntity.internalServerError()
+                    .body(Map.of("error",e.getMessage()));
+        }
+
+    }
+
+}

--- a/blog/blog/src/main/java/com/example/demo/dto/member/google/GoogleOAuthProperties.java
+++ b/blog/blog/src/main/java/com/example/demo/dto/member/google/GoogleOAuthProperties.java
@@ -1,0 +1,18 @@
+package com.example.demo.dto.member.google;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "spring.security.oauth2.client.registration.google")
+public class GoogleOAuthProperties {
+
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+
+}

--- a/blog/blog/src/main/java/com/example/demo/dto/member/google/GoogleUserInfoDTO.java
+++ b/blog/blog/src/main/java/com/example/demo/dto/member/google/GoogleUserInfoDTO.java
@@ -1,0 +1,15 @@
+package com.example.demo.dto.member.google;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GoogleUserInfoDTO {
+
+    private String id; //provideId
+    private String nickname;
+    private String email;
+    private String picture;
+
+}

--- a/blog/blog/src/main/java/com/example/demo/entity/member/MemberEntity.java
+++ b/blog/blog/src/main/java/com/example/demo/entity/member/MemberEntity.java
@@ -1,23 +1,25 @@
 package com.example.demo.entity.member;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Setter
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @SequenceGenerator(
         name = "member",
         sequenceName = "member_seq",
         allocationSize = 1
 )
 @Table(name = "member")
+@Builder
 public class MemberEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "member")
     @Column
-    private long memberId;
+    private Long memberId;
 
     @Column
     private String username;
@@ -41,5 +43,4 @@ public class MemberEntity {
     private String providerId;
 
 
-    public MemberEntity() {}
 }

--- a/blog/blog/src/main/java/com/example/demo/repository/member/MemberRepository.java
+++ b/blog/blog/src/main/java/com/example/demo/repository/member/MemberRepository.java
@@ -23,4 +23,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
     // 카카오
     Optional<MemberEntity> findByProviderId(String id);
+
+    Optional<MemberEntity> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/blog/blog/src/main/java/com/example/demo/service/member/GoogleOAuthService.java
+++ b/blog/blog/src/main/java/com/example/demo/service/member/GoogleOAuthService.java
@@ -1,0 +1,102 @@
+package com.example.demo.service.member;
+
+
+
+import com.example.demo.dto.member.google.GoogleOAuthProperties;
+import com.example.demo.dto.member.google.GoogleUserInfoDTO;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleOAuthService {
+
+    private final GoogleOAuthProperties googleOAuthProperties;
+    private final WebClient.Builder webClientBuilder;
+    private final MemberService memberService;
+
+    //구글 로그인 페이지 URL 생성
+    public String getGoogleAuthUrl(){
+        String url ="https://accounts.google.com/o/oauth2/v2/auth"
+                + "?client_id=" + googleOAuthProperties.getClientId()
+                + "&redirect_uri=" + googleOAuthProperties.getRedirectUri()
+                + "&response_type=code"
+                + "&scope=openid%20profile%20email";
+        log.debug("[Google] 생성된 인증 URL: {}", url);
+        log.debug("[Google] clientId : {}",googleOAuthProperties.getClientId());
+        log.debug("[google] redirectUri : {}",googleOAuthProperties.getRedirectUri());
+        return url;
+    }
+
+    // 인가 코드 -> 엑세스 토큰
+    public String getAccessToken(String code){
+        log.debug("[Google] clientSecret 앞 5자리: {}",
+                googleOAuthProperties.getClientSecret() );
+        WebClient webClient = webClientBuilder.baseUrl("https://oauth2.googleapis.com").build();
+
+        JsonNode response = webClient.post()
+                .uri("/token")
+                .header("Content-type","application/x-www-form-urlencoded")
+                .bodyValue("grant_type=authorization_code"
+                + "&client_id="+ googleOAuthProperties.getClientId()
+                + "&client_secret="+ googleOAuthProperties.getClientSecret()
+                + "&redirect_uri="+ googleOAuthProperties.getRedirectUri()
+                + "&code="+code)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+
+        if(response == null || response.has("error")){
+            throw new RuntimeException("구글 토큰 발급 실패: "+ (response != null ? response.get("error_description").asText() : "응답없음"));
+
+        }
+
+        return response.get("access_token").asText();
+    }
+
+    // 엑세스 토큰 -> 사용자 정보
+    public GoogleUserInfoDTO getGoogleUserInfo(String accessToken){
+
+        WebClient webClient = webClientBuilder.baseUrl("https://www.googleapis.com").build();
+
+        JsonNode userinfo = webClient.get()
+                .uri("/oauth2/v3/userinfo")
+                .header("Authorization","Bearer "+accessToken)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+
+        if(userinfo == null || userinfo.has("error")){
+            throw new RuntimeException("구글 사용자 정보 조회 실패");
+        }
+
+        return GoogleUserInfoDTO.builder()
+                .id(userinfo.get("sub").asText())
+                .email(userinfo.get("email").asText())
+                .nickname(userinfo.get("name").asText())
+                .picture(userinfo.get("picture").asText(null))
+                .build();
+    }
+
+    public String processLoginAndGetRedirectUrl(String code){
+        String accessToken = getAccessToken(code);
+        GoogleUserInfoDTO userinfo = getGoogleUserInfo(accessToken);
+        String jwtToken = memberService.googleLoginOrSignupAndGetJwt(userinfo);
+
+        String encodedNickname = URLEncoder.encode(
+                userinfo.getNickname(), StandardCharsets.UTF_8);
+
+        return "http://localhost:5173"
+                + "?token=" + jwtToken
+                + "&nickname=" +encodedNickname;
+    }
+
+}

--- a/blog/blog/src/main/java/com/example/demo/service/member/MemberService.java
+++ b/blog/blog/src/main/java/com/example/demo/service/member/MemberService.java
@@ -1,5 +1,6 @@
 package com.example.demo.service.member;
 
+import com.example.demo.dto.member.google.GoogleUserInfoDTO;
 import com.example.demo.dto.member.kakao.KakaoUserInfoDTO;
 import com.example.demo.dto.member.MemberDTO;
 
@@ -15,4 +16,6 @@ public interface MemberService {
     String socialLoginOrSignupAndGetJwt(KakaoUserInfoDTO userInfo);
 
     MemberDTO getMemberInfoById(Long memberId);
+
+    String googleLoginOrSignupAndGetJwt(GoogleUserInfoDTO userinfo);
 }

--- a/blog/blog/src/main/java/com/example/demo/service/member/MemberServiceImpl.java
+++ b/blog/blog/src/main/java/com/example/demo/service/member/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.demo.service.member;
 
+import com.example.demo.dto.member.google.GoogleUserInfoDTO;
 import com.example.demo.dto.member.kakao.KakaoUserInfoDTO;
 import com.example.demo.dto.member.MemberDTO;
 import com.example.demo.entity.member.MemberEntity;
@@ -9,6 +10,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public class MemberServiceImpl implements MemberService{
@@ -98,6 +100,31 @@ public class MemberServiceImpl implements MemberService{
                 memberEntity.getRole(),         // 6. String (role)
                 memberEntity.getProvider(),     // 7. String (provider)
                 memberEntity.getProviderId()    // 8. String (providerId)
+        );
+    }
+
+    @Override
+    public String googleLoginOrSignupAndGetJwt(GoogleUserInfoDTO userinfo) {
+
+        MemberEntity member = memberRepository
+                .findByProviderAndProviderId("google",userinfo.getId())
+                .orElseGet(()->{
+                    MemberEntity newMember = MemberEntity.builder()
+                            .username("google_"+userinfo.getId())
+                            .password(UUID.randomUUID().toString())
+                            .nickname(userinfo.getNickname())
+                            .email(userinfo.getEmail())
+                            .role("ROLE_USER")
+                            .provider("google")
+                            .providerId(userinfo.getId())
+                            .build();
+                    return memberRepository.save(newMember);
+                });
+
+        return jwtTokenProvider.createToken(
+                member.getUsername(),
+                member.getRole(),
+                member.getNickname()
         );
     }
 }

--- a/blog/blog/src/main/resources/application.properties
+++ b/blog/blog/src/main/resources/application.properties
@@ -25,6 +25,12 @@ kakao.oauth.redirect-uri=http://localhost:8000/login/oauth2/code/kakao
 kakao.oauth.token-uri=https://kauth.kakao.com/oauth/token
 kakao.oauth.user-info-uri=https://kapi.kakao.com/v2/user/me
 
+# Google OAuth2
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
+spring.security.oauth2.client.registration.google.scope=profile,email
+spring.security.oauth2.client.registration.google.redirect-uri=${GOOGLE_REDIRECT_URI}
+
 # ???? ??
 springdoc.sweager-ui.path = /swagger-ui.html
 springdoc.api-docs.path=/v1/api-docs
@@ -34,10 +40,12 @@ springdoc.info.title= Our Board API Project
 springdoc.info.version=v1.0.0
 springdoc.info.description = 게시판 및 회원 관리 서비스 API 문서
 
-jwt.secret-key=aVerySecureAndLongKeyForHS256AlgorithmTestingWhichIsAtLeast32Bytes
+jwt.secret-key=${JWT_SECRET_KEY}
 
 # Actuator
 management.endpoints.web.exposure.include=prometheus,health,info
 
 # Grafana
 management.metrics.tags.application=blog
+
+logging.level.com.example.demo=DEBUG


### PR DESCRIPTION
-Google Cloud Console 설정
-프로젝트 생성 및 OAuth 동의 화면 구성
-클라이언트 ID/Secret 발급
-승인된 리다이렉션 URL 등록
-환경 변수 등록
-properties에 google OAuth2 등록
-GoogleUserInfoDTO, GoogleOAuthProperties, GoogleOAuthService, GoogleController 생성 및 작성 -MemberEntity 빌더에 맞게 수정
-SecurityConfig에 접근 권한 설정 및 경로 추가