### PR TITLE
[fix/#45] 카카오 OAuth 로그인 오류 수정 및 인증 방식 통일

### DIFF
--- a/blog/blog/src/main/java/com/example/demo/controller/member/GoogleController.java
+++ b/blog/blog/src/main/java/com/example/demo/controller/member/GoogleController.java
@@ -1,6 +1,8 @@
 package com.example.demo.controller.member;
 
 import com.example.demo.service.member.GoogleOAuthService;
+import com.example.demo.service.member.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -18,6 +20,7 @@ import java.util.Map;
 public class GoogleController {
 
     private final GoogleOAuthService googleOAuthService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @GetMapping("/api/v1/oauth/google/url")
     public ResponseEntity<Map<String,String>> getGoogleAuthUrl(){
@@ -27,9 +30,14 @@ public class GoogleController {
     }
 
     @GetMapping("/login/oauth2/code/google")
-    public ResponseEntity<?> googleCallback(@RequestParam("code") String code){
+    public ResponseEntity<?> googleCallback(@RequestParam("code") String code, HttpServletResponse response){
         try{
-            String redirectUrl = googleOAuthService.processLoginAndGetRedirectUrl(code);
+//            String redirectUrl = googleOAuthService.processLoginAndGetRedirectUrl(code);
+            String[] result = googleOAuthService.processLoginAndGetRedirectUrl(code);
+            String redirectUrl = result[0];
+            String jwtToken = result[1];
+            jwtTokenProvider.addTokenToCookie(response,jwtToken);
+
             return ResponseEntity.status(HttpStatus.FOUND)
                     .header(HttpHeaders.LOCATION,redirectUrl)
                     .build();

--- a/blog/blog/src/main/java/com/example/demo/controller/member/KakaoController.java
+++ b/blog/blog/src/main/java/com/example/demo/controller/member/KakaoController.java
@@ -1,8 +1,10 @@
 package com.example.demo.controller.member;
 
 import com.example.demo.dto.member.kakao.KakaoUserInfoDTO;
+import com.example.demo.service.member.JwtTokenProvider;
 import com.example.demo.service.member.KakaoOAuthService;
 import com.example.demo.service.member.MemberService;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -20,10 +22,12 @@ import java.util.Map;
 public class KakaoController {
     private final KakaoOAuthService kakaoOAuthService;
     private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public KakaoController(KakaoOAuthService kakaoOAuthService, MemberService memberService) {
+    public KakaoController(KakaoOAuthService kakaoOAuthService, MemberService memberService, JwtTokenProvider jwtTokenProvider) {
         this.kakaoOAuthService = kakaoOAuthService;
         this.memberService = memberService;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     // 로그인 시작 URL 제공
@@ -47,7 +51,7 @@ public class KakaoController {
     private String frontedUrl;
 
     @GetMapping("/login/oauth2/code/kakao")
-    public ResponseEntity<?> kakaoCallback(@RequestParam("code") String code) {
+    public ResponseEntity<?> kakaoCallback(@RequestParam("code") String code, HttpServletResponse response) {
 
         try {
             // 1. 인가 코드로 액세스 토큰 발급
@@ -70,10 +74,12 @@ public class KakaoController {
 
             // 3. 사용자 정보(userInfo)를 기반으로 서비스 회원가입/로그인 처리 (TODO: MemberService 호출)
             String jwtToken = memberService.socialLoginOrSignupAndGetJwt(userInfo);
-            String userNickname = userInfo.getNickname(); // 카카오에서 받은 닉네임
+//            String userNickname = userInfo.getNickname(); // 카카오에서 받은 닉네임
 
-            String encodeNickname = URLEncoder.encode(userNickname, StandardCharsets.UTF_8.toString());
+            String encodeNickname = URLEncoder.encode(userInfo.getNickname(), StandardCharsets.UTF_8.toString());
 
+            //쿠키에 토큰 심기
+            jwtTokenProvider.addTokenToCookie(response,jwtToken);
 
             // 4. 자체 인증(JWT) 토큰 발급 후 프론트엔드의 메인 페이지로 리다이렉트
             // 물음표는 URL에서 쿼리 문자열이 시작됨을 나타냄
@@ -81,8 +87,8 @@ public class KakaoController {
             // jwtToken 은 데이터의 Value
             // & 를 사용하여 닉네임 파라미터 추가
             String redirectUrl = frontedUrl
-                    + "?token=" + jwtToken
-                    + "&nickname=" + encodeNickname;
+//                    + "?token=" + jwtToken
+                    + "?nickname=" + encodeNickname;
 
             return ResponseEntity.status(HttpStatus.FOUND) // HTTP 302 Found 응답
                     .header(HttpHeaders.LOCATION, redirectUrl)

--- a/blog/blog/src/main/java/com/example/demo/service/member/CustomUserDetails.java
+++ b/blog/blog/src/main/java/com/example/demo/service/member/CustomUserDetails.java
@@ -34,6 +34,8 @@ public class CustomUserDetails implements UserDetails {
         if(role == null){
             // Spring Security Role은 'ROLE_' 접두사 사용하는 것이 일반적입니다.
             role = "ROLE_USER";
+        } else{
+            role = role.toUpperCase();
         }
         this.authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
 

--- a/blog/blog/src/main/java/com/example/demo/service/member/CustomUserService.java
+++ b/blog/blog/src/main/java/com/example/demo/service/member/CustomUserService.java
@@ -23,7 +23,7 @@ public class CustomUserService implements UserDetailsService {
 
         String role = memberEntity.getRole();
         if(role == null){
-            role = "role_user";
+            role = "ROLE_USER";
         }
         System.out.println("조회된 memberId: " + memberEntity.getMemberId());
 

--- a/blog/blog/src/main/java/com/example/demo/service/member/GoogleOAuthService.java
+++ b/blog/blog/src/main/java/com/example/demo/service/member/GoogleOAuthService.java
@@ -91,17 +91,24 @@ public class GoogleOAuthService {
     @Value("${fronted.url}")
     public String frontedUrl;
 
-    public String processLoginAndGetRedirectUrl(String code){
+//    public String processLoginAndGetRedirectUrl(String code){
+//        String accessToken = getAccessToken(code);
+//        GoogleUserInfoDTO userinfo = getGoogleUserInfo(accessToken);
+//        String jwtToken = memberService.googleLoginOrSignupAndGetJwt(userinfo);
+//
+//        String encodedNickname = URLEncoder.encode(
+//                userinfo.getNickname(), StandardCharsets.UTF_8);
+//
+//        return frontedUrl
+//                + "?token=" + jwtToken
+//                + "&nickname=" +encodedNickname;
+//    }
+    public String[] processLoginAndGetRedirectUrl(String code){
         String accessToken = getAccessToken(code);
         GoogleUserInfoDTO userinfo = getGoogleUserInfo(accessToken);
         String jwtToken = memberService.googleLoginOrSignupAndGetJwt(userinfo);
-
-        String encodedNickname = URLEncoder.encode(
-                userinfo.getNickname(), StandardCharsets.UTF_8);
-
-        return frontedUrl
-                + "?token=" + jwtToken
-                + "&nickname=" +encodedNickname;
+        String encodeNickname = URLEncoder.encode(userinfo.getNickname(),StandardCharsets.UTF_8);
+        String redirectUrl = frontedUrl + "?nickname=" + encodeNickname;
+        return new String[]{redirectUrl,jwtToken};
     }
-
 }

--- a/blog/blog/src/main/java/com/example/demo/service/member/JwtAuthenticationFilter.java
+++ b/blog/blog/src/main/java/com/example/demo/service/member/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -14,7 +15,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -30,6 +31,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         for (Cookie cookie : request.getCookies()) {
             // JwtTokenProvider에서 설정한 쿠키 이름인 "accessToken"을 사용합니다.
             if ("accessToken".equals(cookie.getName())) {
+                String value = cookie.getValue();
+
+                log.debug("accessToken 반환 값: [{}]", value);
+                log.debug("accessToken 길이: {}", value != null ? value.length() : 0);
                 return cookie.getValue();
             }
         }
@@ -42,12 +47,24 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
             throws ServletException, IOException {
 
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                log.debug("쿠키 확인: name={}, value={}",cookie.getName(),cookie.getValue());
+            }
+        } else {
+            log.warn("요청에 쿠키가 없습니다. URI={}", request.getRequestURI());
+        }
         // 1. Authorization 헤더에서 토큰을 추출 (기존 방식 유지 - 혹시 모를 Bearer 토큰 요청 대비)
         String token = null;
         String header = request.getHeader("Authorization");
 
         if (header != null && header.startsWith("Bearer ")) {
-            token = header.substring(7).trim();
+            String extracted = header.substring(7).trim();
+            if(!extracted.isEmpty()){
+                token =extracted;
+            }
+//            token = header.substring(7).trim();
+
         }
 
         // 2. Authorization 헤더에 토큰이 없으면 HttpOnly 쿠키에서 토큰을 추출 (⭐ 핵심 수정 ⭐)
@@ -56,6 +73,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         if (token != null) {
+            log.debug("파싱할 토큰 : [{}]",token);
             try {
                 // 토큰 유효성 검사 및 클레임 파싱
                 Claims claims = jwtTokenProvider.parseClaims(token);
@@ -74,7 +92,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             } catch (Exception e) {
                 // 토큰이 유효하지 않은 경우 (만료, 변조 등)
-                logger.warn("JWT 인증 실패: {}" + e.getMessage());
+                log.warn("JWT 인증 실패: {}" , e.getMessage());
             }
         }
 

--- a/blog/blog/src/main/java/com/example/demo/service/member/KakaoOAuthService.java
+++ b/blog/blog/src/main/java/com/example/demo/service/member/KakaoOAuthService.java
@@ -4,7 +4,12 @@ import com.example.demo.dto.member.kakao.KakaoOAuthProperties;
 import com.example.demo.dto.member.kakao.KakaoUserInfoDTO;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 @Service
 public class KakaoOAuthService {
@@ -26,15 +31,25 @@ public class KakaoOAuthService {
 
     // 인가 코드(code)를 사용해 카카오한테 액세스 토큰 발급받기
     public String getAccessToken(String code) {
-        // 🚨 실제 구현에서는 에러 처리 로직이 추가되어야 합니다.
+//        // 🚨 실제 구현에서는 에러 처리 로직이 추가되어야 합니다.
+
+        MultiValueMap<String,String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type","authorization_code");
+        params.add("client_id",kakaoProperties.getClientId());
+        params.add("redirect_uri",kakaoProperties.getRedirectUri());
+        params.add("code",code);
         JsonNode responseNode = webClient.post()
                 .uri(kakaoProperties.getTokenUri())
                 .header("Content-Type", "application/x-www-form-urlencoded")
-                .bodyValue("grant_type=authorization_code" +
-                        "&client_id=" + kakaoProperties.getClientId() +
-                        "&redirect_uri=" + kakaoProperties.getRedirectUri() +
-                        "&code=" + code)
+//                .bodyValue("grant_type=authorization_code" +
+//                        "&client_id=" + kakaoProperties.getClientId() +
+//                        "&redirect_uri=" + kakaoProperties.getRedirectUri() +
+//                        "&code=" + code)
+                .bodyValue(params)
                 .retrieve()
+                .onStatus(status -> status.is4xxClientError(), clientResponse -> clientResponse.bodyToMono(String.class)
+                        .doOnNext(body -> System.out.println("카카오 에러 응답: "+body))
+                        .then(Mono.error(new RuntimeException("카카오 400 에러"))))
                 .bodyToMono(JsonNode.class)
                 .block(); // 블로킹 방식으로 응답 대기
 
@@ -73,9 +88,16 @@ public class KakaoOAuthService {
         if (userInfo.has("kakao_account")) {
             JsonNode kakaoAccount = userInfo.get("kakao_account");
             // 이메일 동의 항목에 따라 'email' 필드의 존재 여부가 달라집니다.
-            if (kakaoAccount.has("email_needs_agreement") && kakaoAccount.get("email_needs_agreement").asBoolean() == false) {
+//            if (kakaoAccount.has("email_needs_agreement") && kakaoAccount.get("email_needs_agreement").asBoolean() == false) {
+//                email = kakaoAccount.get("email").asText();
+//            }
+            if(kakaoAccount.has("email")){
                 email = kakaoAccount.get("email").asText();
             }
+
+        }
+        if(email == null){
+            email = "kakao_"+id+"@kakao.com";
         }
 
         // ⭐️ KakaoUserInfoDto 객체를 생성하여 반환합니다.


### PR DESCRIPTION
KakaoOAuthService.getAccessToken() : 토큰 요청 파라미터를 MultiValueMap 으로 변경하여 자동 URL 인코딩 처리
KakaoOAuthService.getKakaoUserInfo() : 이메일의 경우 kakao_{id}@kakao.com 형태의 임시 이메일 생성
KakaoController : 리다이렉트 URl의 ?token= 제거, ?nickname=만 전달하도록 수정 (JWT는 쿠키로 처리)
GoogleController : 구글 콜백 부분 토큰 제거
GoogleOAuthService : 리다이렉트 부분 토큰 제거

resolves: #45