### PR TITLE
[feat/#51] 게시글/댓글 강제 삭제 및 사용자 차단 기능 구현

### DIFF
--- a/blog/blog/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/blog/blog/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -116,8 +116,10 @@ public class SecurityConfig {
                         // 3-4. 테스트용 (필요시 제거)
                         .requestMatchers("/api/v1/test/**").authenticated()
 
-                        // 3-54 마이페이지
+                        // 3-5 마이페이지
                         .requestMatchers("/api/v1/mypage","/api/v1/mypage/*").authenticated()
+                        // 3-6 신고
+                        .requestMatchers(HttpMethod.POST,"/api/v1/reports/**").authenticated()
 
                         // ========================================================
                         // [GROUP 4] 조회 기능 (누구나 접근 가능) - 나중에 선언!

--- a/blog/blog/src/main/java/com/example/demo/controller/admin/AdminController.java
+++ b/blog/blog/src/main/java/com/example/demo/controller/admin/AdminController.java
@@ -1,0 +1,86 @@
+package com.example.demo.controller.admin;
+
+import com.example.demo.entity.report.ReportEntity;
+import com.example.demo.service.admin.AdminService;
+import com.example.demo.service.admin.AdminServiceImpl;
+import com.example.demo.service.member.CustomUserDetails;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 어드민 전용 컨트롤러
+ * SecurityConfig 에서 /api/v1/admin/** -> hasRole("ADMIN") 으로 보호됨
+ * @PreAuthrize 이중 방어선 역할
+ */
+@RestController
+@RequestMapping("/api/v1/boards/admin")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    // 게시글 강제 삭제
+
+    /**
+     * DELETE /api/v1/boards/admin/{boardId}
+     */
+
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<Map<String,String>> deleteBoard(@PathVariable Long boardId){
+        adminService.deleteBoard(boardId);
+        return ResponseEntity.ok(Map.of("message","게시글이 삭제되었습니다."));
+
+    }
+
+    // 댓글 강제 삭제
+
+    /**
+     *  DELETE /api/v1/boards/admin/comments/{commentId}
+     */
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<Map<String,String>> deleteComment(@PathVariable Long commentId){
+        adminService.deleteComment(commentId);
+        return ResponseEntity.ok(Map.of("message","댓글이 삭제되었습니다."));
+    }
+
+    // 수동 차단
+    /**
+     * POST /api/v1/boards/admin/members/{memberId}/block
+     */
+
+    @PostMapping("/members/{memberId}/block")
+    public ResponseEntity<Map<String,String >> blockMember(@PathVariable Long memberId){
+        adminService.blockMember(memberId);
+        return ResponseEntity.ok(Map.of("message","회원이 차단되었습니다."));
+    }
+
+    /**
+     *  DELETE /api/v1/boards/admin/members/{memberId}/block
+     */
+    @DeleteMapping("/members/{memberId}/block")
+    public ResponseEntity<Map<String,String >> unblockMember(@PathVariable Long memberId){
+        adminService.unblockMember(memberId);
+        return ResponseEntity.ok(Map.of("message","차단이 해제되었습니다."));
+    }
+
+    // 신고 내역 조회
+    /**
+     * GET /api/v1/boards/admin/members/{memberId}/reports
+     */
+    @GetMapping("/members/{memberId}/reports")
+    public ResponseEntity<List<ReportEntity>> getReports(@PathVariable Long memberId){
+        return ResponseEntity.ok(adminService.getReports(memberId));
+    }
+
+
+}
+

--- a/blog/blog/src/main/java/com/example/demo/controller/report/ReportController.java
+++ b/blog/blog/src/main/java/com/example/demo/controller/report/ReportController.java
@@ -1,0 +1,50 @@
+package com.example.demo.controller.report;
+
+import com.example.demo.service.admin.AdminService;
+import com.example.demo.service.member.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * 신고 접수 컨트롤러
+ * 로그인한 사용자라면 누구나 신고 가능
+ */
+@RestController
+@RequestMapping("/api/v1/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final AdminService adminService;
+
+    // 신고 접수 (인증된 사용자라면 누구나 가능)
+
+    /**
+     *  POST /api/v1/reports/{targetId}
+     *  특정 회원 신고 접수
+     *
+     * @param targetId 신고당한 회원 id
+     * @param req      신고 사유, 관련 게시글/댓글 id
+     * @param userDetails 신고한 회원 (로그인 필수)
+     */
+    @PostMapping("/{targetId}")
+    public ResponseEntity<Map<String,String >> report(
+            @PathVariable Long targetId,
+            @RequestBody ReportRequest req,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        adminService.report(
+                userDetails.getMemberId(), //신고자
+                targetId,                  //신고 대상
+                req.reason(),
+                req.boardId(),
+                req.commentId()
+        );
+        return ResponseEntity.ok(Map.of("message","신고가 접수되었습니다."));
+    }
+
+    record ReportRequest(String reason, Long boardId, Long commentId){}
+}

--- a/blog/blog/src/main/java/com/example/demo/entity/member/MemberEntity.java
+++ b/blog/blog/src/main/java/com/example/demo/entity/member/MemberEntity.java
@@ -42,5 +42,22 @@ public class MemberEntity {
     @Column
     private String providerId;
 
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private String status ="ACTIVE";
+
+    public void block(){
+        this.status="BLOCKED";
+    }
+
+    public void unblock(){
+        this.status="ACTIVE";
+    }
+
+    public boolean isBlocked(){
+        return "BLOCKED".equals(this.status);
+    }
+
+
 
 }

--- a/blog/blog/src/main/java/com/example/demo/entity/report/ReportEntity.java
+++ b/blog/blog/src/main/java/com/example/demo/entity/report/ReportEntity.java
@@ -1,0 +1,49 @@
+package com.example.demo.entity.report;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "report")
+@Getter
+@NoArgsConstructor
+@SequenceGenerator(name = "report_seq",sequenceName = "report_seq",allocationSize = 1)
+public class ReportEntity {
+
+    @Id
+    @Column(name = "report_id")
+    @GeneratedValue(generator = "report_seq",strategy = GenerationType.SEQUENCE)
+    private Long reportId;
+
+    @Column(name = "reporter_id",nullable = false)
+    private Long reporterId;
+
+    @Column(name = "target_id",nullable = false)
+    private Long targetId;
+
+    @Column(name = "reason",nullable = false,length = 500)
+    private String reason;
+
+    @Column(name = "board_id")
+    private Long boardId;
+
+    @Column(name = "comment_id")
+    private Long commentId;
+
+    @Column(name = "created_at",nullable = false,updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public ReportEntity(Long reporterId, Long targetId, String reason, Long boardId, Long commentId){
+        this.reporterId = reporterId;
+        this.targetId = targetId;
+        this.reason = reason;
+        this.boardId = boardId;
+        this.commentId = commentId;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/blog/blog/src/main/java/com/example/demo/repository/report/ReportRepository.java
+++ b/blog/blog/src/main/java/com/example/demo/repository/report/ReportRepository.java
@@ -1,0 +1,15 @@
+package com.example.demo.repository.report;
+
+import com.example.demo.entity.report.ReportEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReportRepository extends JpaRepository<ReportEntity , Long> {
+
+    //특정 회원의 신고 내역 전체 조회
+    List<ReportEntity> findAllByTargetId(Long targetId);
+
+    // 특정 회원이 신고당한 횟수
+    long countByTargetId(Long targetId);
+}

--- a/blog/blog/src/main/java/com/example/demo/service/admin/AdminService.java
+++ b/blog/blog/src/main/java/com/example/demo/service/admin/AdminService.java
@@ -1,0 +1,19 @@
+package com.example.demo.service.admin;
+
+import com.example.demo.entity.report.ReportEntity;
+
+import java.util.List;
+
+public interface AdminService {
+    void deleteBoard(Long boardId);
+
+    void deleteComment(Long commentId);
+
+    void blockMember(Long memberId);
+
+    List<ReportEntity> getReports(Long memberId);
+
+    void report(Long memberId, Long targetId, String reason, Long boardId, Long commentId);
+
+    void unblockMember(Long memberId);
+}

--- a/blog/blog/src/main/java/com/example/demo/service/admin/AdminServiceImpl.java
+++ b/blog/blog/src/main/java/com/example/demo/service/admin/AdminServiceImpl.java
@@ -1,0 +1,180 @@
+package com.example.demo.service.admin;
+
+import com.example.demo.entity.board.BoardCommentEntity;
+import com.example.demo.entity.board.BoardEntity;
+import com.example.demo.entity.member.MemberEntity;
+import com.example.demo.entity.report.ReportEntity;
+import com.example.demo.repository.board.BoardCommentRepository;
+import com.example.demo.repository.board.BoardRepository;
+import com.example.demo.repository.member.MemberRepository;
+import com.example.demo.repository.report.ReportRepository;
+import com.example.demo.service.board.BoardSearchService;
+import com.example.demo.service.file.FileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 어드민 서비스
+ * - 게시글 강제 삭제 : 기존 deleteBoard 와 동일하게 파일 -> ES 색인까지 제거
+ * - 댓글 강제 삭제 : 기존 deleteComment 와 동일하게 소프트 딜리트
+ * - 신고 접수 및 누적 3회 자동 차단
+ * - 수동 차단 / 차단 해제
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminServiceImpl implements AdminService {
+
+    private final BoardRepository boardRepository;
+    private final BoardCommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final ReportRepository reportRepository;
+    private final FileService fileService;
+    private final BoardSearchService boardSearchService;
+
+    private static final long BLOCK_THRESHOLD = 3;
+
+    // 게시글 강제 삭제
+    @Transactional
+    @Override
+    public void deleteBoard(Long boardId) {
+        BoardEntity board = boardRepository.findById(boardId).orElseThrow(()-> new IllegalArgumentException("존재하지 않는 게시글입니다. id="+boardId));
+
+        // 1. 본문 이미지 파일 삭제 (기존 로직과 동일)
+        if(board.getContent() !=null && !board.getContent().isEmpty()){
+            Set<String> imgUrls =extractImageUrls(board.getContent());
+            for(String imgUrl : imgUrls){
+                String physicalPath = getPhysicalFilePath(imgUrl);
+                if(physicalPath != null){
+                    try {
+                        fileService.deleteFile(physicalPath);
+                        log.info("[ADMIN] 이미지 파일 삭제 성공:{}",physicalPath);
+                    } catch (Exception e){
+                        log.error("[ADMIN] 이미지 파일 삭제 실패 : {}.{}",physicalPath,e.getMessage());
+                    }
+                }
+            }
+        }
+
+        // 2. 첨부 파일 삭제 (기존 로직과 동일)
+        if(board.getFilePath() !=null && !board.getFilePath().isEmpty()){
+            String pthsicalPath = getPhysicalFilePath(board.getFilePath());
+            if(pthsicalPath != null){
+                try{
+                    fileService.deleteFile(pthsicalPath);
+                    log.info("[ADMIN] 첨부 파일 삭제 성공 :{}",pthsicalPath);
+                } catch (Exception e){
+                    log.error("[ADMIN] 첨부 파일 삭제 실패 : {}, {}",pthsicalPath,e.getMessage());
+                }
+            }
+        }
+
+        // 3. 게시글 하드 딜리트
+        boardRepository.deleteById(boardId);
+        log.warn("[ADMIN] 게시글 강제 삭제 완료 - boardId={}",boardId);
+
+        // 4. ES 색인 삭제
+        try{
+            boardSearchService.delete(boardId);
+        } catch (Exception e){
+            log.error("[ADMIN][ES] 게시글 색인 삭제 실패 boardId={}, {}",boardId,e.getMessage());
+        }
+    }
+
+    // 댓글 강제 삭제
+    @Transactional
+    @Override
+    public void deleteComment(Long commentId) {
+        BoardCommentEntity comment = commentRepository.findById(commentId).orElseThrow(()->new IllegalArgumentException("존재하지 않는 댓글입니다. id="+commentId));
+
+        // 기존 방식과 동일하게 소프트 딜리트
+        comment.setDeleted(true);
+        commentRepository.save(comment);
+        log.warn("[ADMIN] 댓글 강제 삭제 완료 commentId ={}",commentId);
+
+    }
+
+    // 수동 차단
+    @Transactional
+    @Override
+    public void blockMember(Long memberId) {
+        MemberEntity member = memberRepository.findById(memberId).orElseThrow(()->new IllegalArgumentException("존재하지 않는 회원입니다. id="+memberId));
+        member.block();
+        log.warn("[ADMIN] 회원 차단 - memberId={}, userName={}",memberId,member.getUsername());
+
+    }
+
+    // 차단 해제
+    @Transactional
+    @Override
+    public void unblockMember(Long memberId) {
+        MemberEntity member = memberRepository.findById(memberId).orElseThrow(()->new IllegalArgumentException("존재하지 않느 회원입니다. id="+memberId));
+        member.unblock();
+        log.info("[ADMIN] 회원 차단 해제 memberId ={}, username={}",memberId,member.getUsername());
+
+    }
+
+    // 신고 내역 조회
+    @Transactional
+    @Override
+    public List<ReportEntity> getReports(Long targetId) {
+        return reportRepository.findAllByTargetId(targetId);
+    }
+
+    // 신고 접수
+    @Transactional
+    @Override
+    public void report(Long reporterId, Long targetId, String reason, Long boardId, Long commentId) {
+        if(reporterId.equals(targetId)){
+            throw new IllegalArgumentException("자기 자신을 신고할 수 없습니다.");
+        }
+
+        reportRepository.save(ReportEntity.builder()
+                .reporterId(reporterId)
+                .targetId(targetId)
+                .reason(reason)
+                .boardId(boardId)
+                .commentId(commentId)
+                .build());
+
+        long count = reportRepository.countByTargetId(targetId);
+        log.info("[ADMIN] 신고 접수 - targetId= {}, 누적횟수 = {}",targetId, count);
+
+        if(count >=BLOCK_THRESHOLD){
+            blockMember(targetId);
+        }
+
+    }
+
+    // 유틸: 이미지 URL 추출/ 물리 경로 반환 (기존 BoardService 와 동일)
+
+    private Set<String> extractImageUrls(String content){
+        Set<String> urls = new HashSet<>();
+        Pattern pattern = Pattern.compile("!\\[.*?]\\((.*?)\\)|<img[^>]+src=[\"'](.*?)[\"']");
+        Matcher matcher = pattern.matcher(content);
+        while(matcher.find()){
+            String url = matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
+            if(url != null && !url.isBlank()) urls.add(url);
+        }
+        return urls;
+    }
+
+    private String getPhysicalFilePath(String fileUrl){
+        if(fileUrl == null || fileUrl.isBlank()) return null;
+        String uploadRoot ="C:/upload";
+        if(fileUrl.startsWith("/images/")){
+            return uploadRoot + fileUrl.substring("/images".length());
+        }
+        return null;
+    }
+
+
+}

--- a/blog/blog/src/main/java/com/example/demo/service/member/CustomUserDetails.java
+++ b/blog/blog/src/main/java/com/example/demo/service/member/CustomUserDetails.java
@@ -22,12 +22,14 @@ public class CustomUserDetails implements UserDetails {
     private final String nickname;
     private final String password;
     private final Collection<? extends GrantedAuthority> authorities;
+    private final boolean blocked;
 
     public CustomUserDetails(MemberEntity memberEntity) {
         this.memberId = memberEntity.getMemberId();
         this.username = memberEntity.getUsername();
         this.password = memberEntity.getPassword();
         this.nickname = memberEntity.getNickname();
+        this.blocked = memberEntity.isBlocked();
 
         // 권한 설정
         String role = memberEntity.getRole();
@@ -64,7 +66,7 @@ public class CustomUserDetails implements UserDetails {
     public boolean isAccountNonExpired() { return true; }
 
     @Override
-    public boolean isAccountNonLocked() { return true; }
+    public boolean isAccountNonLocked() { return !blocked; }
 
     @Override
     public boolean isCredentialsNonExpired() { return true; }

--- a/blog/blog/src/main/java/com/example/demo/service/member/JwtAuthenticationFilter.java
+++ b/blog/blog/src/main/java/com/example/demo/service/member/JwtAuthenticationFilter.java
@@ -8,6 +8,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -82,6 +84,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 UserDetails userDetails = customUserService.loadUserByUsername(username);
 
                 if (userDetails != null) {
+
+                    if(!userDetails.isAccountNonLocked()){
+                        log.warn("[AUTH] 차단된 회원 요청 거부 - username={} URI={}",username,request.getRequestURI());
+                        sendBlockedResponse(response);
+                        return;
+                    }
+
                     // 인증 객체 생성 및 SecurityContext에 저장
                     UsernamePasswordAuthenticationToken authentication =
                             new UsernamePasswordAuthenticationToken(
@@ -99,4 +108,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
 
     }
+
+    private void sendBlockedResponse(HttpServletResponse response) throws IOException{
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(
+                "{\"status\":403,\"error\":\"Forbidden\",\"message\":\"차단된 계정입니다. 관리자에게 문의하세요.\"}"
+        );
+    }
+
 }


### PR DESCRIPTION
- ReportEntity 및 ReportRepository 추가
- AdminService / AdminServiceImpl/ AdminController 추가
- ReportController 추가
- MemberEntity status 칼럼 추가 (ACTIVE/BLOCKED)
- 신고 누적 3회 이상 자동 차단 처리
- JwtAuthenticationFilter 차단 회원 인증 거부 처리
 resolves: #51