### PR TITLE
[refactor/#67] 닉네임 칼럼 제거 및 회원 조인

### DIFF
--- a/blog/blog/src/main/java/com/example/demo/document/BoardDocument.java
+++ b/blog/blog/src/main/java/com/example/demo/document/BoardDocument.java
@@ -58,11 +58,13 @@ public class BoardDocument {
                 .map(bh -> bh.getHashtag().getName())
                 .collect(Collectors.toList());
 
+        String nickname = (board.getMember() !=null) ? board.getMember().getNickname() : null;
+
         return BoardDocument.builder()
                 .boardId(board.getBoardId())
                 .title(board.getTitle())
                 .contentSummary(board.getContentSummary())
-                .nickname(board.getNickname())
+                .nickname(nickname)
                 .category(board.getCategory())
                 .likes(board.getLikes())
                 .views(board.getViews())

--- a/blog/blog/src/main/java/com/example/demo/dto/board/BoardRequestDTO.java
+++ b/blog/blog/src/main/java/com/example/demo/dto/board/BoardRequestDTO.java
@@ -22,8 +22,8 @@ public class BoardRequestDTO {
         @Size(max = 50000,message = "내용이 너무 깁니다.")
         private String content;
 
-        @Size(max = 50,message = "닉네임은 50자를 초과할 수 없습니다.")
-        private String nickname;
+//        @Size(max = 50,message = "닉네임은 50자를 초과할 수 없습니다.")
+//        private String nickname;
 
         @Size(max = 50,message = "카테고리는 50자를 초과할 수 없습니다.")
         private String category;

--- a/blog/blog/src/main/java/com/example/demo/dto/board/BoardResponse.java
+++ b/blog/blog/src/main/java/com/example/demo/dto/board/BoardResponse.java
@@ -43,13 +43,21 @@ public record BoardResponse(
     // 💡 기존 서비스 코드 호환용 오버로딩 메서드들 (이게 없어서 에러가 났던 것!)
     // =========================================================================
 
+    private static String resolveNickname(BoardEntity entity){
+        if(entity.getMember() != null){
+            return entity.getMember().getNickname();
+        }
+        return null;
+    }
+
+
     // 1. (Entity, Tags, Summary, isAuthor) - 상세 조회용
     public static BoardResponse fromEntity(BoardEntity entity, List<String> tags, String summary, boolean isAuthor) {
         return new BoardResponse(
                 entity.getBoardId(),
                 entity.getTitle(),
                 summary, // 전달받은 요약 사용
-                entity.getNickname(),
+                resolveNickname(entity),
                 entity.getFilePath(),
                 entity.getFileOriginalName(),
                 entity.getFileSize(),
@@ -69,7 +77,7 @@ public record BoardResponse(
                 entity.getBoardId(),
                 entity.getTitle(),
                 summary,
-                entity.getNickname(),
+                resolveNickname(entity),
                 entity.getFilePath(),
                 entity.getFileOriginalName(),
                 entity.getFileSize(),

--- a/blog/blog/src/main/java/com/example/demo/entity/board/BoardEntity.java
+++ b/blog/blog/src/main/java/com/example/demo/entity/board/BoardEntity.java
@@ -30,7 +30,7 @@ public class BoardEntity {
     @Lob
     private String content;
 
-    private String nickname;
+//    private String nickname;
 
     @Column(name = "file_path")
     private String filePath;
@@ -71,7 +71,7 @@ public class BoardEntity {
 
     public void update(
             String title,
-            String nickname,
+//            String nickname,
             String content,
             String category,
             String fileOriginalName,
@@ -81,7 +81,7 @@ public class BoardEntity {
 
     ){
         this.title = title;
-        this.nickname = nickname;
+//        this.nickname = nickname;
         this.content=content;
         this.category=category;
         this.modifiedDate=LocalDateTime.now();

--- a/blog/blog/src/main/java/com/example/demo/repository/board/BoardRepository.java
+++ b/blog/blog/src/main/java/com/example/demo/repository/board/BoardRepository.java
@@ -29,7 +29,7 @@ public interface BoardRepository extends JpaRepository<BoardEntity,Long> {
                 b.board_id AS boardId, 
                 b.title, 
                 b.content_summary AS contentSummary, 
-                b.nickname, 
+                m.nickname, 
                 b.file_path AS filePath, 
                 b.file_original_name AS fileOriginalName, 
                 b.file_size AS fileSize, 
@@ -73,7 +73,9 @@ public interface BoardRepository extends JpaRepository<BoardEntity,Long> {
     void addViews(@Param("boardId") long boardId, @Param("increment") long increment);
 
     // 1. 단건 조회 시 해시태그 fetch join (작성/수정 후 ES 색인용)
-    @Query("SELECT b FROM BoardEntity b LEFT JOIN FETCH b.boardHashtags bh LEFT JOIN FETCH bh.hashtag WHERE b.boardId = :boardId")
+    @Query("SELECT b FROM BoardEntity b LEFT JOIN FETCH b.member " +
+            "LEFT JOIN FETCH b.boardHashtags bh " +
+            "LEFT JOIN FETCH bh.hashtag WHERE b.boardId = :boardId")
     Optional<BoardEntity> findWithHashtagsById(@Param("boardId") Long boardId);
 
     // 2. 전체 조회 (bulk indexing용)

--- a/blog/blog/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
+++ b/blog/blog/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
@@ -140,7 +140,7 @@ public class BoardServiceImpl implements BoardService {
         BoardEntity entity = BoardEntity.builder()
                 .title(boardRequestDTO.getTitle())
                 .content(htmlContent)
-                .nickname(boardRequestDTO.getNickname())
+//                .nickname(boardRequestDTO.getNickname())
                 .category(boardRequestDTO.getCategory())
                 .inputDate(LocalDateTime.now())
                 .modifiedDate(LocalDateTime.now())
@@ -247,7 +247,7 @@ public class BoardServiceImpl implements BoardService {
 
         board.update(
                 boardRequestDTO.getTitle(),
-                boardRequestDTO.getNickname(),
+//                boardRequestDTO.getNickname(),
                 newHtmlContent,
                 boardRequestDTO.getCategory(),
                 originalFileName,


### PR DESCRIPTION
- BoardEntity에서 nickname 필드 및 update() 파라미터 제거
- BoardRequestDTO에서 nickname 필드 제거
- BoardResponse.fromEntity()에서 member.getNickname()으로 변경
- BoardRepository 네이티브 쿼리 b.nickname → m.nickname 변경
- findWithHashtagsById에 JOIN FETCH b.member 추가
- BoardDocument.from()에서 member 닉네임 조회로 변경 
resolves: #67