### PR TITLE
[feat/#69] Redis 기반 비밀번호 재설정 링크 발송 및 비밀번호 변경 API 구현

### DIFF
--- a/blog/blog/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/blog/blog/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -133,6 +133,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/boards/markdown-preview").permitAll() // 마크다운 미리보기
                         .requestMatchers(HttpMethod.GET, "/api/v1/subscriptions/**").permitAll() // 구독 여부 조회
                         .requestMatchers("/api/v1/email/**").permitAll()
+                        .requestMatchers("/api/v1/password/**").permitAll()
 
                         // ========================================================
                         // [GROUP 5] 그 외 모든 요청

--- a/blog/blog/src/main/java/com/example/demo/controller/member/MemberRestController.java
+++ b/blog/blog/src/main/java/com/example/demo/controller/member/MemberRestController.java
@@ -1,11 +1,9 @@
 package com.example.demo.controller.member;
 
 import com.example.demo.dto.board.MyBoardResponseDTO;
-import com.example.demo.dto.member.LoginRequestDTO;
-import com.example.demo.dto.member.MemberDTO;
-import com.example.demo.dto.member.NicknameChangeRequestDTO;
-import com.example.demo.dto.member.PwChangeRequestDTO;
+import com.example.demo.dto.member.*;
 import com.example.demo.entity.member.MemberEntity;
+import com.example.demo.service.email.EmailService;
 import com.example.demo.service.member.CustomUserDetails;
 import com.example.demo.service.member.JwtTokenProvider;
 import com.example.demo.service.member.MemberService;
@@ -13,12 +11,14 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,11 +27,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@Slf4j
 public class MemberRestController {
 
     private final MemberService memberService;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationManager authenticationManager;
+    private final EmailService emailService;
 
     @PostMapping("/login")
     public ResponseEntity<Map<String, String>> login(@Valid @RequestBody LoginRequestDTO loginRequest, HttpServletResponse response) {
@@ -217,4 +219,51 @@ public class MemberRestController {
         memberService.verifyCurrentPassword(userDetails.getMemberId(),body.get("currentPw"));
         return ResponseEntity.ok(Map.of("message","비밀번호가 확인되었습니다."));
     }
+
+    // 비밀번호 찾기 (재설정 링크 발송)
+    /**
+     * POST /api/v1/password/reset-request
+     * 요청 : {username, email}
+     * 응답 : 항상 동일한 메세지 (계정 존재 여부 노출 방지)
+     */
+    @PostMapping("/password/reset-request")
+    public ResponseEntity<Map<String ,String>>requestPasswordReset(
+            @Valid @RequestBody PasswordResetRequestDTO dto){
+
+        try{
+            emailService.sendPasswordResetLink(dto.getUsername(),dto.getEmail());
+
+            } catch (IllegalArgumentException e){
+            log.debug("[PwReset] 일치하는 계정 없음 - username = {}",dto.getUsername());
+        }
+        return ResponseEntity.ok(Map.of("message","입력하신 이메일로 재설정 링크를 발송했습니다."));
+
+    }
+
+    // 비밀번호 재설정 토큰 유효성 확인
+    /**
+     * GET /api/v1/password/reset-validate?token=...
+     * 프론트 진입 시 토큰 만료 여부 사전 확인용
+     */
+    @GetMapping("/password/reset-validate")
+    public ResponseEntity<Map<String ,Object>> validateResetToken(@RequestParam String token){
+        boolean valid = emailService.isValidResetToken(token);
+        if(!valid){
+            return ResponseEntity.status(HttpStatus.GONE).body(Map.of("valid",false,"message","만료되었거나 유효하지 않은 링크입니다/"));
+        }
+        return ResponseEntity.ok(Map.of("valid",true));
+    }
+
+    // 비밀번호 재설정 처리
+    /**
+     * POST /api/v1/password/reset
+     * 요청 : {token, newPassword}
+     */
+    @PostMapping("/password/reset")
+    public ResponseEntity<Map<String ,String>> resetPassword(
+            @Valid @RequestBody PasswordResetConfirmDTO dto){
+        emailService.resetPassword(dto.getToken(),dto.getNewPassword());
+        return ResponseEntity.ok(Map.of("message","비밀번호가 성공적으로 변경되었습니다."));
+    }
+
 }

--- a/blog/blog/src/main/java/com/example/demo/dto/member/PasswordResetConfirmDTO.java
+++ b/blog/blog/src/main/java/com/example/demo/dto/member/PasswordResetConfirmDTO.java
@@ -1,0 +1,20 @@
+package com.example.demo.dto.member;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordResetConfirmDTO {
+    @NotBlank(message = "토큰이 없습니다.")
+    private String token;
+
+    @NotBlank(message = "새 비밀번호를 입력해주세요")
+    @Size(min = 8,max = 100,message = "비밀번호는 8자 이상 100자 이하여야합니다.")
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).*$",
+            message = "비밀번호는 대문자와 특수문자를 각각 1개 이상 포함해야 합니다.")
+    private String newPassword;
+}

--- a/blog/blog/src/main/java/com/example/demo/dto/member/PasswordResetRequestDTO.java
+++ b/blog/blog/src/main/java/com/example/demo/dto/member/PasswordResetRequestDTO.java
@@ -1,0 +1,16 @@
+package com.example.demo.dto.member;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordResetRequestDTO {
+
+    @NotBlank(message = "아이디를 입력해주세요")
+    private String username;
+
+    @NotBlank(message = "이메일을 입력해주세요")
+    private String email;
+}

--- a/blog/blog/src/main/java/com/example/demo/repository/member/MemberRepository.java
+++ b/blog/blog/src/main/java/com/example/demo/repository/member/MemberRepository.java
@@ -28,4 +28,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
     @Query("SELECT m.username FROM MemberEntity m WHERE m.email = :email")
     Optional<String> findUsernameByEmail(@Param("email") String email);
+
+    Optional<MemberEntity> findByUsernameAndEmail(String username, String email);
 }

--- a/blog/blog/src/main/java/com/example/demo/service/email/EmailService.java
+++ b/blog/blog/src/main/java/com/example/demo/service/email/EmailService.java
@@ -2,6 +2,7 @@ package com.example.demo.service.email;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public interface EmailService {
@@ -14,4 +15,11 @@ public interface EmailService {
     boolean isVerified(@Size(max = 100,message = "이메일은 100자를 초과할 수 없습니다.") @Email(message = "올바른 이메일 형식이 아닙니다.") String email);
 
     void deleteVerified(@Size(max = 100,message = "이메일은 100자를 초과할 수 없습니다.") @Email(message = "올바른 이메일 형식이 아닙니다.") String email);
+
+    void sendPasswordResetLink(@NotBlank(message = "아이디를 입력해주세요") String username, @NotBlank(message = "이메일을 입력해주세요") String email);
+
+    boolean isValidResetToken(String token);
+
+    void resetPassword(@NotBlank(message = "토큰이 없습니다.") String token, @NotBlank(message = "새 비밀번호를 입력해주세요") @Size(min = 8,max = 100,message = "비밀번호는 8자 이상 100자 이하여야합니다.") @Pattern(regexp = "^(?=.*[A-Z])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).*$",
+            message = "비밀번호는 대문자와 특수문자를 각각 1개 이상 포함해야 합니다.") String newPassword);
 }

--- a/blog/blog/src/main/java/com/example/demo/service/email/EmailServiceImpl.java
+++ b/blog/blog/src/main/java/com/example/demo/service/email/EmailServiceImpl.java
@@ -1,15 +1,20 @@
 package com.example.demo.service.email;
 
+import com.example.demo.entity.member.MemberEntity;
 import com.example.demo.repository.member.MemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.Random;
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -19,10 +24,15 @@ public class EmailServiceImpl implements EmailService{
     private final JavaMailSender mailSender;
     private final StringRedisTemplate redisTemplate;
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     // Redis 키 prefix
     private static final String VERIFY_CODE_PREFIX = "email:verify:"; // 인증 코드 (TTL 5분)
     private static final String VERIFIED_PREFIX = "email:verified:"; // 인증 완료 (TTL 10분)
+    private static final String RESET_TOKEN_PREFIX = "reset:"; //비밀번호 재설정 토큰 (TTL 30분)
+
+    @Value("${app.frontend.url:http://localhost:3000}")
+    private String frontedUrl;
 
     // 인증 코드 발송
     @Override
@@ -118,6 +128,63 @@ public class EmailServiceImpl implements EmailService{
     /** 인증 완료 키 삭제 (회원가입 완료 후 처리)*/
     public void deleteVerified(String email){
         redisTemplate.delete(VERIFIED_PREFIX+email);
+    }
+
+
+    // 비밀번호 재설정 링크 발송
+    @Override
+    public void sendPasswordResetLink(String username, String email) {
+        MemberEntity member = memberRepository.findByUsernameAndEmail(username,email)
+                .orElseThrow(()->new IllegalArgumentException("아이디와 이메일 정보가 일치하지 않습니다."));
+
+        String token = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(
+                RESET_TOKEN_PREFIX + token,
+                String.valueOf(member.getMemberId()),
+                Duration.ofMinutes(30)
+        );
+
+        String resetLink = frontedUrl + "/reset-password?token="+token;
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("[Semicolon] 비밀번호 재설정 링크");
+        message.setText(
+                "안녕하세요 Semicolon입니다. \n\n"+
+                "아래 링크를 클릭하여 새 비밀번호를 설정해주세요\n"+
+                        resetLink+"\n\n"+
+                        "링크는 30분간 유효합니다.\n"+
+                        "본인이 요청하지 않은 경우 이 메일을 무시해주세요."
+        );
+        mailSender.send(message);
+        log.info("[Email] 비밀번호 재설정 링크 발송 완료 -email = {}",email);
+    }
+
+    // 토큰 유효성 확인 (프론트 진입 시 사전 체크용)
+    @Override
+    public boolean isValidResetToken(String token) {
+        return redisTemplate.hasKey(RESET_TOKEN_PREFIX + token);
+    }
+
+    // 비밀번호 재설정 관리
+    @Override
+    @Transactional
+    public void resetPassword(String token, String newPassword) {
+        String memberIdStr = redisTemplate.opsForValue().get(RESET_TOKEN_PREFIX + token);
+        if(memberIdStr == null){
+            throw new IllegalArgumentException("유효하지 않거나 만료된 링크입니다.");
+        }
+        Long memberId = Long.parseLong(memberIdStr);
+        MemberEntity member = memberRepository.findById(memberId).orElseThrow(()-> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        if(passwordEncoder.matches(newPassword,member.getPassword())){
+            throw new IllegalArgumentException("현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다.");
+        }
+
+        member.setPassword(passwordEncoder.encode(newPassword));
+
+        redisTemplate.delete(RESET_TOKEN_PREFIX+token);
+        log.info("[Email] 비밀번호 재설정 완료 memberId={}",memberId);
     }
 }
 

--- a/blog/blog/src/main/resources/application.properties
+++ b/blog/blog/src/main/resources/application.properties
@@ -72,5 +72,5 @@ spring.mail.password=${GMAIL_APP_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
-
+app.fronted.url=http://localhost:3000
 


### PR DESCRIPTION
- 비밀번호 찾기 요청 시 입력받은 아이디와 이메일의 DB 정보 일치 여부 검증 추가
- 고유 토큰(UUID) 생성 및 Redis 세션 저장 로직 구현 (Key: reset:{token}, TTL: 30분)
- 프론트엔드 도메인과 토큰이 결합된 비밀번호 재설정 URL SMTP 메일 발송 기능 추가
- 비밀번호 재설정 API 내 Redis 토큰 유효성 및 만료 여부 검증 추가
- 전달받은 새 비밀번호 BCrypt 암호화 적용 및 데이터베이스(Member) 업데이트 구현
- 보안 강화를 위해 비밀번호 변경 완료 직후 사용된 Redis 토큰 즉시 삭제 처리
 resolves: #69